### PR TITLE
Avoid DNS lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fixed spurious CI failures, esp. Windows. [#61](https://github.com/tzaeschke/phtree-cpp/pull/61) 
 - Fix SCM references in pom file + clean up. [#60](https://github.com/tzaeschke/phtree-cpp/pull/60) 
-- DNS lookup caused by `InetAddress.getByName()`. [#62](https://github.com/tzaeschke/phtree-cpp/pull/62)
+- DNS lookup caused by `InetAddress.getByName()`. [#63](https://github.com/tzaeschke/phtree-cpp/pull/63)
 
 ## [0.1.0] - 2024-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fixed spurious CI failures, esp. Windows. [#61](https://github.com/tzaeschke/phtree-cpp/pull/61) 
 - Fix SCM references in pom file + clean up. [#60](https://github.com/tzaeschke/phtree-cpp/pull/60) 
+- DNS lookup caused by `InetAddress.getByName()`. [#62](https://github.com/tzaeschke/phtree-cpp/pull/62)
 
 ## [0.1.0] - 2024-04-29
 

--- a/src/main/java/org/scion/jpan/RequestPath.java
+++ b/src/main/java/org/scion/jpan/RequestPath.java
@@ -21,6 +21,8 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.scion.jpan.internal.IPHelper;
 import org.scion.jpan.proto.daemon.Daemon;
 
 /**
@@ -67,7 +69,7 @@ public class RequestPath extends Path {
     try {
       String underlayAddressString = internalPath.getInterface().getAddress().getAddress();
       int splitIndex = underlayAddressString.indexOf(':');
-      InetAddress ip = InetAddress.getByName(underlayAddressString.substring(0, splitIndex));
+      InetAddress ip = IPHelper.toInetAddress(underlayAddressString.substring(0, splitIndex));
       int port = Integer.parseUnsignedInt(underlayAddressString.substring(splitIndex + 1));
       return new InetSocketAddress(ip, port);
     } catch (UnknownHostException e) {

--- a/src/main/java/org/scion/jpan/RequestPath.java
+++ b/src/main/java/org/scion/jpan/RequestPath.java
@@ -21,7 +21,6 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.scion.jpan.internal.IPHelper;
 import org.scion.jpan.proto.daemon.Daemon;
 

--- a/src/main/java/org/scion/jpan/ScionAddress.java
+++ b/src/main/java/org/scion/jpan/ScionAddress.java
@@ -37,9 +37,9 @@ public class ScionAddress {
     return new ScionAddress(isdAs, address.getHostName(), address);
   }
 
-  static ScionAddress create(long isdAs, String hostName, String ipString) {
+  static ScionAddress create(long isdAs, String hostName, byte[] ipBytes) {
     try {
-      InetAddress ip = InetAddress.getByName(ipString);
+      InetAddress ip = InetAddress.getByAddress(hostName, ipBytes);
       return new ScionAddress(isdAs, hostName, ip);
     } catch (UnknownHostException e) {
       // This should never happen because we always call getByName() with an IP address

--- a/src/main/java/org/scion/jpan/ScionService.java
+++ b/src/main/java/org/scion/jpan/ScionService.java
@@ -36,7 +36,6 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-
 import org.scion.jpan.internal.*;
 import org.scion.jpan.proto.control_plane.SegmentLookupServiceGrpc;
 import org.scion.jpan.proto.daemon.Daemon;

--- a/src/main/java/org/scion/jpan/internal/HostsFileParser.java
+++ b/src/main/java/org/scion/jpan/internal/HostsFileParser.java
@@ -28,6 +28,7 @@ import org.scion.jpan.ScionRuntimeException;
 import org.scion.jpan.ScionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xbill.DNS.Address;
 
 public class HostsFileParser {
 
@@ -107,9 +108,8 @@ public class HostsFileParser {
       check(addrParts[1].endsWith("]"), "Expected `]` after address");
       String addrStr = addrParts[1].substring(1, addrParts[1].length() - 1).trim();
       check(!addrStr.isEmpty(), "Address is empty");
-      // We allow anything here, even host names (which will trigger a DNS lookup).
-      // Is that ok?
-      InetAddress inetAddr = InetAddress.getByName(addrStr);
+
+      byte[] addrBytes = IPHelper.toByteArray(addrStr);
 
       // TODO
       // 4) Singleton ?!?!?!?!!!
@@ -120,12 +120,14 @@ public class HostsFileParser {
           // ignore comments
           break;
         }
+        InetAddress inetAddr = InetAddress.getByAddress(hostName, addrBytes);
         entries.put(hostName, new HostEntry(isdIa, inetAddr, hostName));
       }
       // The following may differ, e.g. for IPv6
       // TODO find a better way, i.e. use InetAddress instances as keys?
+      InetAddress inetAddr = InetAddress.getByAddress(addrStr, addrBytes);
       entries.put(inetAddr.getHostName(), new HostEntry(isdIa, inetAddr, inetAddr.getHostName()));
-      entries.put(addrStr, new HostEntry(isdIa, inetAddr, addrStr));
+      entries.put(inetAddr.getHostAddress(), new HostEntry(isdIa, inetAddr, inetAddr.getHostAddress()));
     } catch (IndexOutOfBoundsException | IllegalArgumentException | UnknownHostException e) {
       LOG.info("ERROR {} while parsing file {}: {}", e.getMessage(), PATH_LINUX, line);
     }

--- a/src/main/java/org/scion/jpan/internal/HostsFileParser.java
+++ b/src/main/java/org/scion/jpan/internal/HostsFileParser.java
@@ -28,7 +28,6 @@ import org.scion.jpan.ScionRuntimeException;
 import org.scion.jpan.ScionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xbill.DNS.Address;
 
 public class HostsFileParser {
 
@@ -127,7 +126,8 @@ public class HostsFileParser {
       // TODO find a better way, i.e. use InetAddress instances as keys?
       InetAddress inetAddr = InetAddress.getByAddress(addrStr, addrBytes);
       entries.put(inetAddr.getHostName(), new HostEntry(isdIa, inetAddr, inetAddr.getHostName()));
-      entries.put(inetAddr.getHostAddress(), new HostEntry(isdIa, inetAddr, inetAddr.getHostAddress()));
+      entries.put(
+          inetAddr.getHostAddress(), new HostEntry(isdIa, inetAddr, inetAddr.getHostAddress()));
     } catch (IndexOutOfBoundsException | IllegalArgumentException | UnknownHostException e) {
       LOG.info("ERROR {} while parsing file {}: {}", e.getMessage(), PATH_LINUX, line);
     }

--- a/src/main/java/org/scion/jpan/internal/IPHelper.java
+++ b/src/main/java/org/scion/jpan/internal/IPHelper.java
@@ -14,10 +14,9 @@
 
 package org.scion.jpan.internal;
 
-import org.xbill.DNS.Address;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import org.xbill.DNS.Address;
 
 public class IPHelper {
   private IPHelper() {}

--- a/src/main/java/org/scion/jpan/internal/IPHelper.java
+++ b/src/main/java/org/scion/jpan/internal/IPHelper.java
@@ -1,0 +1,71 @@
+// Copyright 2024 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion.jpan.internal;
+
+import org.xbill.DNS.Address;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class IPHelper {
+  private IPHelper() {}
+
+  public static boolean isLocalhost(String hostName) {
+    return hostName.startsWith("127.0.0.")
+        || "::1".equals(hostName)
+        || "0:0:0:0:0:0:0:1".equals(hostName)
+        || "localhost".equals(hostName)
+        || "ip6-localhost".equals(hostName);
+  }
+
+  public static byte[] lookupLocalhost(String hostName) {
+    if ("localhost".equals(hostName)) {
+      return new byte[] {127, 0, 0, 1};
+    }
+    if (hostName.startsWith("127.0.0.")) {
+      return Address.toByteArray(hostName, Address.IPv4);
+    }
+
+    if ("::1".equals(hostName)
+        || "0:0:0:0:0:0:0:1".equals(hostName)
+        || "ip6-localhost".equals(hostName)) {
+      return new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    }
+    return null;
+  }
+
+  public static byte[] toByteArray(String s) {
+    if ("localhost".equals(s)) {
+      return new byte[] {127, 0, 0, 1};
+    }
+    if ("localhost-ip6".equals(s)) {
+      return new byte[] {127, 0, 0, 1};
+    }
+    if (s.startsWith("[")) {
+      if (s.endsWith("]")) {
+        s = s.substring(1, s.length() - 1);
+      } else {
+        return null; // Missing closing bracket. Something is wrong.
+      }
+    }
+    int family = Address.isDottedQuad(s) ? Address.IPv4 : Address.IPv6;
+    return Address.toByteArray(s, family);
+  }
+
+  public static InetAddress toInetAddress(String s) throws UnknownHostException {
+    byte[] bytes = toByteArray(s);
+    return InetAddress.getByAddress(bytes);
+  }
+}

--- a/src/test/java/org/scion/jpan/api/ScionServiceTest.java
+++ b/src/test/java/org/scion/jpan/api/ScionServiceTest.java
@@ -218,7 +218,7 @@ public class ScionServiceTest {
       assertNotNull(sAddr);
       assertEquals(1, sAddr.getIsd());
       assertEquals("1-ff00:0:110", ScionUtil.toStringIA(sAddr.getIsdAs()));
-      assertEquals("/127.0.0.1", sAddr.getInetAddress().toString());
+      assertEquals(SCION_HOST + "/127.0.0.1", sAddr.getInetAddress().toString());
       assertEquals(SCION_HOST, sAddr.getHostName());
     } finally {
       System.clearProperty(PackageVisibilityHelper.DEBUG_PROPERTY_DNS_MOCK);
@@ -240,7 +240,7 @@ public class ScionServiceTest {
       assertNotNull(sAddr);
       assertEquals(1, sAddr.getIsd());
       assertEquals("1-ff00:0:110", ScionUtil.toStringIA(sAddr.getIsdAs()));
-      assertEquals("/0:0:0:0:0:0:0:1", sAddr.getInetAddress().toString());
+      assertEquals(SCION_HOST + "/0:0:0:0:0:0:0:1", sAddr.getInetAddress().toString());
       assertEquals(SCION_HOST, sAddr.getHostName());
     } finally {
       System.clearProperty(PackageVisibilityHelper.DEBUG_PROPERTY_DNS_MOCK);

--- a/src/test/resources/etc-scion-hosts
+++ b/src/test/resources/etc-scion-hosts
@@ -17,3 +17,6 @@ ff00:0:114,[42.0.0.10] test-server
 1-ff00:0:114,[hello] test-server
 1-ff00:0:114,[] test-server
 hello,[hello] hello
+1-ff00:0:114,[127.0.0.0.1] test-server
+1-ff00:0:114,[127.0.1] test-server
+


### PR DESCRIPTION
Avoid DNS lookups caused by `InetAddress.getByName()`.