### PR TITLE
Avoid InetAddress.getHostName()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fixed spurious CI failures, esp. Windows. [#61](https://github.com/tzaeschke/phtree-cpp/pull/61) 
 - Fix SCM references in pom file + clean up. [#60](https://github.com/tzaeschke/phtree-cpp/pull/60) 
-- DNS lookup caused by `InetAddress.getByName()`. [#63](https://github.com/tzaeschke/phtree-cpp/pull/63)
+- DNS lookup caused by `InetAddress.getByName()`. [#63](https://github.com/scionproto-contrib/jpan/pull/63)
+- DNS lookup caused by `InetAddress.getHostName()`. [#64](https://github.com/scionproto-contrib/jpan/pull/64)
 
 ## [0.1.0] - 2024-04-29
 
 ### Added
-- Code coverage. [#11](https://github.com/tzaeschke/phtree-cpp/pull/11)
+- Code coverage. [#11](https://github.com/netsec-ethz/scion-java-client/pull/11)
 - Global JUnit callback for initial setup. THis allows setting global properties before centrally
   before running any tests.
   [#38](https://github.com/netsec-ethz/scion-java-client/pull/38)

--- a/src/main/java/org/scion/jpan/ScionService.java
+++ b/src/main/java/org/scion/jpan/ScionService.java
@@ -298,7 +298,8 @@ public class ScionService {
    * @throws IOException if an errors occurs while querying paths.
    */
   public List<RequestPath> getPaths(InetSocketAddress dstAddress) throws IOException {
-    ScionAddress sa = getScionAddress(dstAddress.getHostName());
+    // Use getHostString() to avoid DNS reverse lookup.
+    ScionAddress sa = getScionAddress(dstAddress.getHostString());
     return getPaths(sa.getIsdAs(), sa.getInetAddress(), dstAddress.getPort());
   }
 

--- a/src/test/java/org/scion/jpan/testutil/JUnitSetUp.java
+++ b/src/test/java/org/scion/jpan/testutil/JUnitSetUp.java
@@ -69,6 +69,7 @@ public class JUnitSetUp
 
   @Override
   public void beforeEach(ExtensionContext context) {
+    System.setProperty(Constants.PROPERTY_HOSTS_FILES, "....some-invalid-file");
     Scion.closeDefault();
     if (failed) {
       System.exit(1);


### PR DESCRIPTION
Avoid `InetAddress.getHostName()` because it may trigger a reverse DNS lookup.