### PR TITLE
Path subclasses InetSocketAddress - v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - **BREAKING CHANGE**: ScionDatagramChannel.send(buffer, path) returns 'int'.
 
 TODO
-- Make Path fully immutable?
-  --> How do we refresh Paths? How do we return refreshed paths from send()?
-  --> Maybe not return, but cache refreshed path, either in Path itself (weird?) or
-      in ScionService?
 - Move expiryMargin to ScionService? 
-- Move design doc from Path javadoc to Design.md
-- return value of send()? Separate PR?
+- return value of send()? Separate PR? -> test send() result
 
 TODO general
 - Why are these synchronized, they are only reading? isBlocking(), getPathPolicy(), ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## Added
+### Added
 - SCMP echo responder [#78](https://github.com/scionproto-contrib/jpan/pull/78)
 - Maven Java executor [#80](https://github.com/scionproto-contrib/jpan/pull/80)
 - Dev environment setup hints doc [#82](https://github.com/scionproto-contrib/jpan/pull/82)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - **BREAKING CHANGE**: ScionDatagramChannel.send(buffer, path) returns 'int'.
 TODO
 - Move expiryMargin to ScionService?
+- remove ScionAddress?
+- Remove getPaths(long dstIsdAs, InetSocketAddress dstScionAddress) -< ISD + Scion address!!!
 
 ### Fixed
 - Fixed locking and resizing of buffers. [#68](https://github.com/scionproto-contrib/jpan/pull/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - **BREAKING CHANGE**: Access to path details such as metadata has been moved to 
     `Path.getDetails()`.
   - **BREAKING CHANGE**: ScionDatagramChannel.send(buffer, path) returns 'int'.
-
 TODO
 - Move expiryMargin to ScionService? 
-- return value of send()? Separate PR? -> test send() result
 
 TODO general
 - Why are these synchronized, they are only reading? isBlocking(), getPathPolicy(), ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Rename `ScionSocketOptions`  starting with `SN_` to `SCION_`
 - SCMP API changes. [#71](https://github.com/scionproto-contrib/jpan/pull/71)
 - Make `Path` inherit `InetSocketAddress` [#69](https://github.com/scionproto-contrib/jpan/pull/69) 
-  **BREAKING CHANGE**: Access to path metadata has been moved to `Path.getMetadata()`
+  - **BREAKING CHANGE**: Access to path metadata has been moved to `Path.getMetadata()`.
+  - **BREAKING CHANGE**: ScionDatagramChannel.send(buffer, path) returns 'int'.
 
 TODO
 - Revert metadata being a separate class? go-SNET also has a separate class...
 - Make Path fully immutable?
+  --> How do we refresh Paths? How do we return refreshed paths from send()?
+  --> Maybe not return, but cache refreshed path, either in Path itself (weird?) or
+      in ScionService?
+- Move expiryMargin to ScionService? 
 - Move design doc from Path javadoc to Design.md
 - return value of send()? Separate PR?
-- deprecate/remove getConnectedPath()
 
 ### Fixed
 - Fixed locking and resizing of buffers. [#68](https://github.com/scionproto-contrib/jpan/pull/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     `Path.getDetails()`.
   - **BREAKING CHANGE**: ScionDatagramChannel.send(buffer, path) returns 'int'.
 TODO
-- Move expiryMargin to ScionService? 
-
-TODO general
-- Why are these synchronized, they are only reading? isBlocking(), getPathPolicy(), ...
-  --> volatile?
-- Why disconnect() inside disconnect()?
+- Move expiryMargin to ScionService?
 
 ### Fixed
 - Fixed locking and resizing of buffers. [#68](https://github.com/scionproto-contrib/jpan/pull/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Rename `DatagramSocket` to `ScionDatagramSopcketl` and move it to main package
   - Rename `ScionSocketOptions`  starting with `SN_` to `SCION_`
 - SCMP API changes. [#71](https://github.com/scionproto-contrib/jpan/pull/71)
+- Make `Path` inherit `InetSocketAddress` [#69](https://github.com/scionproto-contrib/jpan/pull/69) 
+
+TODO
+- Revert metadata being a separate class? go-SNET also has a separate class...
+- Make Path fully immutable?
+- Move design doc from Path javadoc to Design.md
+- return value of send()? Separate PR?
 
 ### Fixed
 - Fixed locking and resizing of buffers. [#68](https://github.com/scionproto-contrib/jpan/pull/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Rename `ScionSocketOptions`  starting with `SN_` to `SCION_`
 - SCMP API changes. [#71](https://github.com/scionproto-contrib/jpan/pull/71)
 - Make `Path` inherit `InetSocketAddress` [#69](https://github.com/scionproto-contrib/jpan/pull/69) 
-  - **BREAKING CHANGE**: Access to path metadata has been moved to `Path.getMetadata()`.
+  - **BREAKING CHANGE**: Access to path details such as metadata has been moved to 
+    `Path.getDetails()`.
   - **BREAKING CHANGE**: ScionDatagramChannel.send(buffer, path) returns 'int'.
 
 TODO
-- Revert metadata being a separate class? go-SNET also has a separate class...
 - Make Path fully immutable?
   --> How do we refresh Paths? How do we return refreshed paths from send()?
   --> Maybe not return, but cache refreshed path, either in Path itself (weird?) or
@@ -32,6 +32,11 @@ TODO
 - Move expiryMargin to ScionService? 
 - Move design doc from Path javadoc to Design.md
 - return value of send()? Separate PR?
+
+TODO general
+- Why are these synchronized, they are only reading? isBlocking(), getPathPolicy(), ...
+  --> volatile?
+- Why disconnect() inside disconnect()?
 
 ### Fixed
 - Fixed locking and resizing of buffers. [#68](https://github.com/scionproto-contrib/jpan/pull/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Rename `ScionSocketOptions`  starting with `SN_` to `SCION_`
 - SCMP API changes. [#71](https://github.com/scionproto-contrib/jpan/pull/71)
 - Make `Path` inherit `InetSocketAddress` [#69](https://github.com/scionproto-contrib/jpan/pull/69) 
+  **BREAKING CHANGE**: Access to path metadata has been moved to `Path.getMetadata()`
 
 TODO
 - Revert metadata being a separate class? go-SNET also has a separate class...
 - Make Path fully immutable?
 - Move design doc from Path javadoc to Design.md
 - return value of send()? Separate PR?
+- deprecate/remove getConnectedPath()
 
 ### Fixed
 - Fixed locking and resizing of buffers. [#68](https://github.com/scionproto-contrib/jpan/pull/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ TODO
 - Move expiryMargin to ScionService?
 - remove ScionAddress?
 - Remove getPaths(long dstIsdAs, InetSocketAddress dstScionAddress) -< ISD + Scion address!!!
+- Remove use of getHostName() -> InetAddress!
 
 ### Fixed
 - Fixed locking and resizing of buffers. [#68](https://github.com/scionproto-contrib/jpan/pull/68)

--- a/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
@@ -400,17 +400,13 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
     this.overrideExternalAddress = address;
   }
 
-  protected int sendRaw(ByteBuffer buffer, InetSocketAddress address, Path path)
+  protected int sendRaw(ByteBuffer buffer, Path path)
       throws IOException {
     if (cfgRemoteDispatcher && path != null && path.getRawPath().length == 0) {
-      return channel.send(
-          buffer, new InetSocketAddress(address.getAddress(), Constants.DISPATCHER_PORT));
+      InetAddress remoteHostIP = path.getFirstHopAddress().getAddress();
+      return channel.send(buffer, new InetSocketAddress(remoteHostIP, Constants.DISPATCHER_PORT));
     }
-    return channel.send(buffer, address);
-  }
-
-  protected int sendRaw(ByteBuffer buffer, InetSocketAddress address) throws IOException {
-    return sendRaw(buffer, address, null);
+    return channel.send(buffer, path.getFirstHopAddress());
   }
 
   public Consumer<Scmp.Message> setScmpErrorListener(Consumer<Scmp.Message> listener) {

--- a/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
@@ -611,7 +611,7 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
           rawPath.length,
           srcIA,
           srcAddress.getAddress(),
-          path.getIsdAs(),
+          path.getRemoteIsdAs(),
           path.getRemoteAddress().getAddress(),
           hdrType,
           cfgTrafficClass);

--- a/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
@@ -85,7 +85,7 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
   }
 
   public PathPolicy getPathPolicy() {
-    synchronized (stateLock) { // TODO why synchronized???
+    synchronized (stateLock) {
       return this.pathPolicy;
     }
   }
@@ -190,7 +190,6 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
 
   public void disconnect() throws IOException {
     synchronized (stateLock) {
-      channel.disconnect(); // TODO Why ? We shouldn´t do that...?
       connectionPath = null;
     }
   }

--- a/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
@@ -301,7 +301,9 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
    * #connect(RequestPath)} and may be refreshed when expired.
    *
    * @return the current Path or `null` if not path is connected.
+   * @deprecated Please use getRemoteAddress() instead
    */
+  @Deprecated
   public Path getConnectionPath() {
     synchronized (stateLock) {
       return connectionPath;

--- a/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
@@ -400,9 +400,8 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
     this.overrideExternalAddress = address;
   }
 
-  protected int sendRaw(ByteBuffer buffer, Path path)
-      throws IOException {
-    if (cfgRemoteDispatcher && path != null && path.getRawPath().length == 0) {
+  protected int sendRaw(ByteBuffer buffer, Path path) throws IOException {
+    if (cfgRemoteDispatcher && path.getRawPath().length == 0) {
       InetAddress remoteHostIP = path.getFirstHopAddress().getAddress();
       return channel.send(buffer, new InetSocketAddress(remoteHostIP, Constants.DISPATCHER_PORT));
     }

--- a/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/AbstractDatagramChannel.java
@@ -625,7 +625,8 @@ abstract class AbstractDatagramChannel<C extends AbstractDatagramChannel<?>> imp
 
   protected RequestPath ensureUpToDate(RequestPath path) throws IOException {
     synchronized (stateLock) {
-      if (Instant.now().getEpochSecond() + cfgExpirationSafetyMargin <= path.getExpiration()) {
+      if (Instant.now().getEpochSecond() + cfgExpirationSafetyMargin
+          <= path.getMetadata().getExpiration()) {
         return path;
       }
       // expired, get new path

--- a/src/main/java/org/scion/jpan/Path.java
+++ b/src/main/java/org/scion/jpan/Path.java
@@ -21,16 +21,6 @@ import java.util.Arrays;
  * A Path is an InetSocketAddress/ISD/AS of a destination host plus a path to that host.
  *
  * <p>This class is thread safe.
- *
- * <p>Design considerations:<br>
- * - Having Path inherit InetSocketAddress may feel a bit awkward, not least because
- * getAddress()/getPort() are not immediately clear to refer to the remote host. However,
- * subclassing InetSocketAddress allows paths to be returned from DatagramChannel.receive(), which
- * would otherwise not be possible.<br>
- * - Having two subclasses of Path ensures that RequestPaths and ResponsePath are never mixed up.
- * <br>
- * - The design also allows immutability, and thus thread safety.<br>
- * - Having metadata in a separate class makes the API cleaner.
  */
 public abstract class Path extends InetSocketAddress {
   private final long dstIsdAs;

--- a/src/main/java/org/scion/jpan/Path.java
+++ b/src/main/java/org/scion/jpan/Path.java
@@ -15,56 +15,29 @@
 package org.scion.jpan;
 
 import java.net.*;
-import java.util.Arrays;
 
 /**
  * A Path is an InetSocketAddress/ISD/AS of a destination host plus a path to that host.
  *
  * <p>This class is thread safe.
  */
-public abstract class Path extends InetSocketAddress {
-  private final long dstIsdAs;
+public interface Path {
 
-  protected Path(long dstIsdAs, InetAddress dstIP, int dstPort) {
-    super(dstIP, dstPort);
-    this.dstIsdAs = dstIsdAs;
-  }
+  byte[] getRawPath();
 
-  public abstract byte[] getRawPath();
+  InetSocketAddress getFirstHopAddress() throws UnknownHostException;
 
-  public abstract InetSocketAddress getFirstHopAddress() throws UnknownHostException;
+  int getRemotePort();
 
-  @Deprecated // Use getPort() instead
-  public int getRemotePort() {
-    return getPort();
-  }
+  InetAddress getRemoteAddress();
 
-  @Deprecated // Use getAddress() instead
-  public InetAddress getRemoteAddress() {
-    return getAddress();
-  }
-
-  @Deprecated // Use getIsdAs() instead
-  public long getRemoteIsdAs() {
-    return dstIsdAs;
-  }
+  long getRemoteIsdAs();
 
   /**
    * @return ISD/AS of the remote host.
    */
-  public long getIsdAs() {
-    return dstIsdAs;
-  }
+  long getIsdAs();
 
   @Override
-  public String toString() {
-    return "Path{"
-        + "ISD/AS="
-        + ScionUtil.toStringIA(dstIsdAs)
-        + ", address="
-        + super.toString()
-        + ", pathRaw="
-        + Arrays.toString(getRawPath())
-        + '}';
-  }
+  String toString();
 }

--- a/src/main/java/org/scion/jpan/Path.java
+++ b/src/main/java/org/scion/jpan/Path.java
@@ -23,27 +23,24 @@ import java.util.Arrays;
  * <p>This class is thread safe.
  *
  * <p>Design considerations:<br>
- * - Having Path subclass InetSocketAddress may feel a bit awkward, not least because
+ * - Having Path inherit InetSocketAddress may feel a bit awkward, not least because
  * getAddress()/getPort() are not immediately clear to refer to the remote host. However,
- * subclassing InetSocketAddress allows paths to be returned by DatagramChannel.receive(), which
+ * subclassing InetSocketAddress allows paths to be returned from DatagramChannel.receive(), which
  * would otherwise not be possible.<br>
- * - Having two sublasses of Path ensures that RequestPaths and ResponsePath are never mixed up.<br>
+ * - Having two subclasses of Path ensures that RequestPaths and ResponsePath are never mixed up.
+ * <br>
  * - The design also allows immutability, and thus thread safety.<br>
  * - Having metadata in a separate class makes the API cleaner.
  */
 public abstract class Path extends InetSocketAddress {
-  private final byte[] pathRaw;
   private final long dstIsdAs;
 
-  protected Path(byte[] rawPath, long dstIsdAs, InetAddress dstIP, int dstPort) {
+  protected Path(long dstIsdAs, InetAddress dstIP, int dstPort) {
     super(dstIP, dstPort);
-    this.pathRaw = rawPath;
     this.dstIsdAs = dstIsdAs;
   }
 
-  public byte[] getRawPath() {
-    return pathRaw;
-  }
+  public abstract byte[] getRawPath();
 
   public abstract InetSocketAddress getFirstHopAddress() throws UnknownHostException;
 
@@ -77,7 +74,7 @@ public abstract class Path extends InetSocketAddress {
         + ", address="
         + super.toString()
         + ", pathRaw="
-        + Arrays.toString(pathRaw)
+        + Arrays.toString(getRawPath())
         + '}';
   }
 }

--- a/src/main/java/org/scion/jpan/Path.java
+++ b/src/main/java/org/scion/jpan/Path.java
@@ -33,11 +33,6 @@ public interface Path {
 
   long getRemoteIsdAs();
 
-  /**
-   * @return ISD/AS of the remote host.
-   */
-  long getIsdAs();
-
   @Override
   String toString();
 }

--- a/src/main/java/org/scion/jpan/PathImpl.java
+++ b/src/main/java/org/scion/jpan/PathImpl.java
@@ -1,0 +1,70 @@
+// Copyright 2023 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion.jpan;
+
+import java.net.*;
+import java.util.Arrays;
+
+/**
+ * A Path is an InetSocketAddress/ISD/AS of a destination host plus a path to that host.
+ *
+ * <p>This class is thread safe.
+ */
+abstract class PathImpl extends InetSocketAddress implements Path {
+  private final long dstIsdAs;
+
+  protected PathImpl(long dstIsdAs, InetAddress dstIP, int dstPort) {
+    super(dstIP, dstPort);
+    this.dstIsdAs = dstIsdAs;
+  }
+
+  public abstract byte[] getRawPath();
+
+  public abstract InetSocketAddress getFirstHopAddress() throws UnknownHostException;
+
+  @Deprecated // Use getPort() instead
+  public int getRemotePort() {
+    return getPort();
+  }
+
+  @Deprecated // Use getAddress() instead
+  public InetAddress getRemoteAddress() {
+    return getAddress();
+  }
+
+  @Deprecated // Use getIsdAs() instead
+  public long getRemoteIsdAs() {
+    return dstIsdAs;
+  }
+
+  /**
+   * @return ISD/AS of the remote host.
+   */
+  public long getIsdAs() {
+    return dstIsdAs;
+  }
+
+  @Override
+  public String toString() {
+    return "Path{"
+        + "ISD/AS="
+        + ScionUtil.toStringIA(dstIsdAs)
+        + ", address="
+        + super.toString()
+        + ", pathRaw="
+        + Arrays.toString(getRawPath())
+        + '}';
+  }
+}

--- a/src/main/java/org/scion/jpan/PathMetadata.java
+++ b/src/main/java/org/scion/jpan/PathMetadata.java
@@ -1,0 +1,264 @@
+// Copyright 2023 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion.jpan;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.scion.jpan.proto.daemon.Daemon;
+
+/**
+ * PathMetadata contains additional meta information such as bandwidth, latency or geo coordinates.
+ * PathMetadata is available from a RequestPaths are created/returned by the ScionService when
+ * requesting a new path from the control service.
+ */
+public class PathMetadata {
+
+  private final Daemon.Path pathProtoc;
+
+  static PathMetadata create(Daemon.Path path) {
+    return new PathMetadata(path);
+  }
+
+  private PathMetadata(Daemon.Path path) {
+    this.pathProtoc = path;
+  }
+
+  private Daemon.Path protoPath() {
+    if (pathProtoc == null) {
+      throw new IllegalStateException(
+          "Information is only available for paths that"
+              + " were retrieved directly from a path server.");
+    }
+    return pathProtoc;
+  }
+
+  /**
+   * @return Interface for exiting the local AS using this path.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public Interface getInterface() {
+    return new Interface(protoPath().getInterface());
+  }
+
+  /**
+   * @return The list of interfaces the path is composed of.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<PathInterface> getInterfacesList() {
+    return Collections.unmodifiableList(
+        protoPath().getInterfacesList().stream()
+            .map(PathInterface::new)
+            .collect(Collectors.toList()));
+  }
+
+  /**
+   * @return The maximum transmission unit (MTU) on the path.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public int getMtu() {
+    return protoPath().getMtu();
+  }
+
+  /**
+   * @return The point in time when this path expires. In seconds since UNIX epoch.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public long getExpiration() {
+    return protoPath().getExpiration().getSeconds();
+  }
+
+  /**
+   * @return Latency lists the latencies between any two consecutive interfaces. Entry i describes
+   *     the latency between interface i and i+1. Consequently, there are N-1 entries for N
+   *     interfaces. A 0-value indicates that the AS did not announce a latency for this hop.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<Integer> getLatencyList() {
+    return Collections.unmodifiableList(
+        protoPath().getLatencyList().stream()
+            .map(time -> (int) (time.getSeconds() * 1_000 + time.getNanos() / 1_000_000))
+            .collect(Collectors.toList()));
+  }
+
+  /**
+   * @return Bandwidth lists the bandwidth between any two consecutive interfaces, in Kbit/s. Entry
+   *     i describes the bandwidth between interfaces i and i+1. A 0-value indicates that the AS did
+   *     not announce a bandwidth for this hop.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<Long> getBandwidthList() {
+    return protoPath().getBandwidthList();
+  }
+
+  /**
+   * @return Geo lists the geographical position of the border routers along the path. Entry i
+   *     describes the position of the router for interface i. A 0-value indicates that the AS did
+   *     not announce a position for this router.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<GeoCoordinates> getGeoList() {
+    return Collections.unmodifiableList(
+        protoPath().getGeoList().stream().map(GeoCoordinates::new).collect(Collectors.toList()));
+  }
+
+  /**
+   * @return LinkType contains the announced link type of inter-domain links. Entry i describes the
+   *     link between interfaces 2*i and 2*i+1.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<LinkType> getLinkTypeList() {
+    return Collections.unmodifiableList(
+        protoPath().getLinkTypeList().stream()
+            .map(linkType -> LinkType.values()[linkType.getNumber()])
+            .collect(Collectors.toList()));
+  }
+
+  /**
+   * @return InternalHops lists the number of AS internal hops for the ASes on path. Entry i
+   *     describes the hop between interfaces 2*i+1 and 2*i+2 in the same AS. Consequently, there
+   *     are no entries for the first and last ASes, as these are not traversed completely by the
+   *     path.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<Integer> getInternalHopsList() {
+    return protoPath().getInternalHopsList();
+  }
+
+  /**
+   * @return Notes contains the notes added by ASes on the path, in the order of occurrence. Entry i
+   *     is the note of AS i on the path.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<String> getNotesList() {
+    return protoPath().getNotesList();
+  }
+
+  /**
+   * @return EpicAuths contains the EPIC authenticators used to calculate the PHVF and LHVF.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public EpicAuths getEpicAuths() {
+    return new EpicAuths(protoPath().getEpicAuths());
+  }
+
+  public enum LinkType {
+    /** Unspecified link type. */
+    LINK_TYPE_UNSPECIFIED, // = 0
+    /** Direct physical connection. */
+    LINK_TYPE_DIRECT, // = 1
+    /** Connection with local routing/switching. */
+    LINK_TYPE_MULTI_HOP, // = 2
+    /** Connection overlayed over publicly routed Internet. */
+    LINK_TYPE_OPEN_NET, // = 3
+  }
+
+  public static class EpicAuths {
+    private final byte[] authPhvf;
+    private final byte[] authLhvf;
+
+    private EpicAuths(Daemon.EpicAuths epicAuths) {
+      this.authPhvf = epicAuths.getAuthPhvf().toByteArray();
+      this.authLhvf = epicAuths.getAuthLhvf().toByteArray();
+    }
+
+    /**
+     * @return AuthPHVF is the authenticator use to calculate the PHVF.
+     */
+    public byte[] getAuthPhvf() {
+      return authPhvf;
+    }
+
+    /**
+     * @return AuthLHVF is the authenticator use to calculate the LHVF.
+     */
+    public byte[] getAuthLhvf() {
+      return authLhvf;
+    }
+  }
+
+  public static class Interface {
+    private final String address;
+
+    private Interface(Daemon.Interface inter) {
+      this.address = inter.getAddress().getAddress();
+    }
+
+    /**
+     * @return Underlay address to exit through the interface.
+     */
+    public String getAddress() {
+      return address;
+    }
+  }
+
+  public static class PathInterface {
+    private final long isdAs;
+
+    private final long id;
+
+    private PathInterface(Daemon.PathInterface pathInterface) {
+      this.isdAs = pathInterface.getIsdAs();
+      this.id = pathInterface.getId();
+    }
+
+    /**
+     * @return ISD-AS the interface belongs to.
+     */
+    public long getIsdAs() {
+      return isdAs;
+    }
+
+    /**
+     * @return ID of the interface in the AS.
+     */
+    public long getId() {
+      return id;
+    }
+  }
+
+  public static class GeoCoordinates {
+    private final float latitude;
+    private final float longitude;
+    private final String address;
+
+    private GeoCoordinates(Daemon.GeoCoordinates geoCoordinates) {
+      this.latitude = geoCoordinates.getLatitude();
+      this.longitude = geoCoordinates.getLongitude();
+      this.address = geoCoordinates.getAddress();
+    }
+
+    /**
+     * @return Latitude of the geographic coordinate, in the WGS 84 datum.
+     */
+    public float getLatitude() {
+      return latitude;
+    }
+
+    /**
+     * @return Longitude of the geographic coordinate, in the WGS 84 datum.
+     */
+    public float getLongitude() {
+      return longitude;
+    }
+
+    /**
+     * @return Civic address of the location.
+     */
+    public String getAddress() {
+      return address;
+    }
+  }
+}

--- a/src/main/java/org/scion/jpan/PathPolicy.java
+++ b/src/main/java/org/scion/jpan/PathPolicy.java
@@ -32,7 +32,7 @@ public interface PathPolicy {
   class MaxBandwith implements PathPolicy {
     public RequestPath filter(List<RequestPath> paths) {
       return paths.stream()
-          .max(Comparator.comparing(path -> Collections.min(path.getBandwidthList())))
+          .max(Comparator.comparing(path -> Collections.min(path.getMetadata().getBandwidthList())))
           .orElseThrow(NoSuchElementException::new);
     }
   }
@@ -45,7 +45,7 @@ public interface PathPolicy {
           .min(
               Comparator.comparing(
                   path ->
-                      path.getLatencyList().stream()
+                      path.getMetadata().getLatencyList().stream()
                           .mapToLong(l -> l > 0 ? l : Integer.MAX_VALUE)
                           .reduce(0, Long::sum)))
           .orElseThrow(NoSuchElementException::new);
@@ -55,7 +55,7 @@ public interface PathPolicy {
   class MinHopCount implements PathPolicy {
     public RequestPath filter(List<RequestPath> paths) {
       return paths.stream()
-          .min(Comparator.comparing(path -> path.getInternalHopsList().size()))
+          .min(Comparator.comparing(path -> path.getMetadata().getInternalHopsList().size()))
           .orElseThrow(NoSuchElementException::new);
     }
   }
@@ -76,7 +76,7 @@ public interface PathPolicy {
     }
 
     private boolean checkPath(RequestPath path) {
-      for (RequestPath.PathInterface pif : path.getInterfacesList()) {
+      for (PathMetadata.PathInterface pif : path.getMetadata().getInterfacesList()) {
         int isd = (int) (pif.getIsdAs() >>> 48);
         if (!allowedIsds.contains(isd)) {
           return false;
@@ -102,7 +102,7 @@ public interface PathPolicy {
     }
 
     private boolean checkPath(RequestPath path) {
-      for (RequestPath.PathInterface pif : path.getInterfacesList()) {
+      for (PathMetadata.PathInterface pif : path.getMetadata().getInterfacesList()) {
         int isd = (int) (pif.getIsdAs() >>> 48);
         if (disallowedIsds.contains(isd)) {
           return false;

--- a/src/main/java/org/scion/jpan/PathPolicy.java
+++ b/src/main/java/org/scion/jpan/PathPolicy.java
@@ -32,7 +32,7 @@ public interface PathPolicy {
   class MaxBandwith implements PathPolicy {
     public RequestPath filter(List<RequestPath> paths) {
       return paths.stream()
-          .max(Comparator.comparing(path -> Collections.min(path.getMetadata().getBandwidthList())))
+          .max(Comparator.comparing(path -> Collections.min(path.getDetails().getBandwidthList())))
           .orElseThrow(NoSuchElementException::new);
     }
   }
@@ -45,7 +45,7 @@ public interface PathPolicy {
           .min(
               Comparator.comparing(
                   path ->
-                      path.getMetadata().getLatencyList().stream()
+                      path.getDetails().getLatencyList().stream()
                           .mapToLong(l -> l > 0 ? l : Integer.MAX_VALUE)
                           .reduce(0, Long::sum)))
           .orElseThrow(NoSuchElementException::new);
@@ -55,7 +55,7 @@ public interface PathPolicy {
   class MinHopCount implements PathPolicy {
     public RequestPath filter(List<RequestPath> paths) {
       return paths.stream()
-          .min(Comparator.comparing(path -> path.getMetadata().getInternalHopsList().size()))
+          .min(Comparator.comparing(path -> path.getDetails().getInternalHopsList().size()))
           .orElseThrow(NoSuchElementException::new);
     }
   }
@@ -76,7 +76,7 @@ public interface PathPolicy {
     }
 
     private boolean checkPath(RequestPath path) {
-      for (PathMetadata.PathInterface pif : path.getMetadata().getInterfacesList()) {
+      for (PathDetails.PathInterface pif : path.getDetails().getInterfacesList()) {
         int isd = (int) (pif.getIsdAs() >>> 48);
         if (!allowedIsds.contains(isd)) {
           return false;
@@ -102,7 +102,7 @@ public interface PathPolicy {
     }
 
     private boolean checkPath(RequestPath path) {
-      for (PathMetadata.PathInterface pif : path.getMetadata().getInterfacesList()) {
+      for (PathDetails.PathInterface pif : path.getDetails().getInterfacesList()) {
         int isd = (int) (pif.getIsdAs() >>> 48);
         if (disallowedIsds.contains(isd)) {
           return false;

--- a/src/main/java/org/scion/jpan/RequestPath.java
+++ b/src/main/java/org/scion/jpan/RequestPath.java
@@ -14,92 +14,48 @@
 
 package org.scion.jpan;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.time.Instant;
-
-import org.scion.jpan.internal.IPHelper;
+import java.util.concurrent.atomic.AtomicReference;
 import org.scion.jpan.proto.daemon.Daemon;
 
 /**
  * A RequestPath is a Path with additional meta information such as bandwidth, latency or geo
  * coordinates. RequestPaths are created/returned by the ScionService when requesting a new path
  * from the control service.
+ *
+ * <p>A RequestPath is immutable except for an atomic reference to PathDetails (PathDetails are
+ * immutable). The reference may be updated, for example when a path expires.
  */
 public class RequestPath extends Path {
 
-  private final PathMetadata metadata;
-  // We store the first hop separately to void creating unnecessary objects.
-  private final InetSocketAddress firstHop;
+  private final AtomicReference<PathDetails> details = new AtomicReference<>();
 
   static RequestPath create(Daemon.Path path, long dstIsdAs, InetAddress dstIP, int dstPort) {
     return new RequestPath(path, dstIsdAs, dstIP, dstPort);
   }
 
   private RequestPath(Daemon.Path path, long dstIsdAs, InetAddress dstIP, int dstPort) {
-    super(path.getRaw().toByteArray(), dstIsdAs, dstIP, dstPort);
-    this.metadata = PathMetadata.create(path);
-    if (getRawPath().length == 0) {
-      // local AS has path length 0
-      firstHop = new InetSocketAddress(getRemoteAddress(), getRemotePort());
-    } else {
-      firstHop = getFirstHopAddress(path);
-    }
+    super(dstIsdAs, dstIP, dstPort);
+    this.details.set(PathDetails.create(path, dstIP, dstPort));
   }
 
   @Override
   public InetSocketAddress getFirstHopAddress() throws UnknownHostException {
-    return firstHop;
+    return getDetails().getFirstHopAddress();
   }
 
-  private InetSocketAddress getFirstHopAddress(Daemon.Path internalPath) {
-    try {
-      String underlayAddressString = internalPath.getInterface().getAddress().getAddress();
-      int splitIndex = underlayAddressString.indexOf(':');
-      InetAddress ip = IPHelper.toInetAddress(underlayAddressString.substring(0, splitIndex));
-      int port = Integer.parseUnsignedInt(underlayAddressString.substring(splitIndex + 1));
-      return new InetSocketAddress(ip, port);
-    } catch (UnknownHostException e) {
-      // This really should never happen, the first hop is a literal IP address.
-      throw new UncheckedIOException(e);
-    }
+  @Override
+  public byte[] getRawPath() {
+    return getDetails().getRawPath();
   }
 
-  public PathMetadata getMetadata() {
-    return metadata;
+  public PathDetails getDetails() {
+    return details.get();
   }
 
-//  /**
-//   * @param service Service for obtaining new paths when required
-//   * @param pathPolicy PathPolicy for selecting a new path when required
-//   * @param expiryMargin Expiry margin, i.e. a path is considered "expired" if expiry is less than
-//   *     expiryMargin seconds away.
-//   * @return `false` if the path is `null`, it it is a ResponsePath or if it didn't need updating.
-//   *     Returns `true` only if the path was updated.
-//   */
-//  synchronized boolean refreshPath(ScionService service, PathPolicy pathPolicy, int expiryMargin)
-//          throws IOException {
-////    if (path == null) {
-////      path = pathPolicy.filter(service.getPaths(this));
-////      if (path == null) {
-////        throw new IOException("Address is not resolvable in SCION: " + super.toString());
-////      }
-////      return true;
-////    }
-////
-////    if (!(path instanceof RequestPath)) {
-////      return false;
-////    }
-////
-////    RequestPath requestPath = (RequestPath) path;
-//    if (Instant.now().getEpochSecond() + expiryMargin <= getMetadata().getExpiration()) {
-//      return false;
-//    }
-//    // expired, get new path
-//    path = pathPolicy.filter(service.getPaths(requestPath));
-//    return true;
-//  }
+  void setDetails(PathDetails details) {
+    this.details.set(details);
+  }
 }

--- a/src/main/java/org/scion/jpan/RequestPath.java
+++ b/src/main/java/org/scion/jpan/RequestPath.java
@@ -14,10 +14,13 @@
 
 package org.scion.jpan;
 
+import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.time.Instant;
+
 import org.scion.jpan.internal.IPHelper;
 import org.scion.jpan.proto.daemon.Daemon;
 
@@ -68,4 +71,35 @@ public class RequestPath extends Path {
   public PathMetadata getMetadata() {
     return metadata;
   }
+
+//  /**
+//   * @param service Service for obtaining new paths when required
+//   * @param pathPolicy PathPolicy for selecting a new path when required
+//   * @param expiryMargin Expiry margin, i.e. a path is considered "expired" if expiry is less than
+//   *     expiryMargin seconds away.
+//   * @return `false` if the path is `null`, it it is a ResponsePath or if it didn't need updating.
+//   *     Returns `true` only if the path was updated.
+//   */
+//  synchronized boolean refreshPath(ScionService service, PathPolicy pathPolicy, int expiryMargin)
+//          throws IOException {
+////    if (path == null) {
+////      path = pathPolicy.filter(service.getPaths(this));
+////      if (path == null) {
+////        throw new IOException("Address is not resolvable in SCION: " + super.toString());
+////      }
+////      return true;
+////    }
+////
+////    if (!(path instanceof RequestPath)) {
+////      return false;
+////    }
+////
+////    RequestPath requestPath = (RequestPath) path;
+//    if (Instant.now().getEpochSecond() + expiryMargin <= getMetadata().getExpiration()) {
+//      return false;
+//    }
+//    // expired, get new path
+//    path = pathPolicy.filter(service.getPaths(requestPath));
+//    return true;
+//  }
 }

--- a/src/main/java/org/scion/jpan/RequestPath.java
+++ b/src/main/java/org/scion/jpan/RequestPath.java
@@ -18,9 +18,6 @@ import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.scion.jpan.internal.IPHelper;
 import org.scion.jpan.proto.daemon.Daemon;
 
@@ -31,7 +28,7 @@ import org.scion.jpan.proto.daemon.Daemon;
  */
 public class RequestPath extends Path {
 
-  private final Daemon.Path pathProtoc;
+  private final PathMetadata metadata;
   // We store the first hop separately to void creating unnecessary objects.
   private final InetSocketAddress firstHop;
 
@@ -41,22 +38,13 @@ public class RequestPath extends Path {
 
   private RequestPath(Daemon.Path path, long dstIsdAs, InetAddress dstIP, int dstPort) {
     super(path.getRaw().toByteArray(), dstIsdAs, dstIP, dstPort);
-    this.pathProtoc = path;
+    this.metadata = PathMetadata.create(path);
     if (getRawPath().length == 0) {
       // local AS has path length 0
       firstHop = new InetSocketAddress(getRemoteAddress(), getRemotePort());
     } else {
-      firstHop = getFirstHopAddress(pathProtoc);
+      firstHop = getFirstHopAddress(path);
     }
-  }
-
-  private Daemon.Path protoPath() {
-    if (pathProtoc == null) {
-      throw new IllegalStateException(
-          "Information is only available for paths that"
-              + " were retrieved directly from a path server.");
-    }
-    return pathProtoc;
   }
 
   @Override
@@ -77,220 +65,7 @@ public class RequestPath extends Path {
     }
   }
 
-  /**
-   * @return Interface for exiting the local AS using this path.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public Interface getInterface() {
-    return new Interface(protoPath().getInterface());
-  }
-
-  /**
-   * @return The list of interfaces the path is composed of.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<PathInterface> getInterfacesList() {
-    return Collections.unmodifiableList(
-        protoPath().getInterfacesList().stream()
-            .map(PathInterface::new)
-            .collect(Collectors.toList()));
-  }
-
-  /**
-   * @return The maximum transmission unit (MTU) on the path.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public int getMtu() {
-    return protoPath().getMtu();
-  }
-
-  /**
-   * @return The point in time when this path expires. In seconds since UNIX epoch.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public long getExpiration() {
-    return protoPath().getExpiration().getSeconds();
-  }
-
-  /**
-   * @return Latency lists the latencies between any two consecutive interfaces. Entry i describes
-   *     the latency between interface i and i+1. Consequently, there are N-1 entries for N
-   *     interfaces. A 0-value indicates that the AS did not announce a latency for this hop.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<Integer> getLatencyList() {
-    return Collections.unmodifiableList(
-        protoPath().getLatencyList().stream()
-            .map(time -> (int) (time.getSeconds() * 1_000 + time.getNanos() / 1_000_000))
-            .collect(Collectors.toList()));
-  }
-
-  /**
-   * @return Bandwidth lists the bandwidth between any two consecutive interfaces, in Kbit/s. Entry
-   *     i describes the bandwidth between interfaces i and i+1. A 0-value indicates that the AS did
-   *     not announce a bandwidth for this hop.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<Long> getBandwidthList() {
-    return protoPath().getBandwidthList();
-  }
-
-  /**
-   * @return Geo lists the geographical position of the border routers along the path. Entry i
-   *     describes the position of the router for interface i. A 0-value indicates that the AS did
-   *     not announce a position for this router.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<GeoCoordinates> getGeoList() {
-    return Collections.unmodifiableList(
-        protoPath().getGeoList().stream().map(GeoCoordinates::new).collect(Collectors.toList()));
-  }
-
-  /**
-   * @return LinkType contains the announced link type of inter-domain links. Entry i describes the
-   *     link between interfaces 2*i and 2*i+1.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<LinkType> getLinkTypeList() {
-    return Collections.unmodifiableList(
-        protoPath().getLinkTypeList().stream()
-            .map(linkType -> LinkType.values()[linkType.getNumber()])
-            .collect(Collectors.toList()));
-  }
-
-  /**
-   * @return InternalHops lists the number of AS internal hops for the ASes on path. Entry i
-   *     describes the hop between interfaces 2*i+1 and 2*i+2 in the same AS. Consequently, there
-   *     are no entries for the first and last ASes, as these are not traversed completely by the
-   *     path.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<Integer> getInternalHopsList() {
-    return protoPath().getInternalHopsList();
-  }
-
-  /**
-   * @return Notes contains the notes added by ASes on the path, in the order of occurrence. Entry i
-   *     is the note of AS i on the path.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<String> getNotesList() {
-    return protoPath().getNotesList();
-  }
-
-  /**
-   * @return EpicAuths contains the EPIC authenticators used to calculate the PHVF and LHVF.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public EpicAuths getEpicAuths() {
-    return new EpicAuths(protoPath().getEpicAuths());
-  }
-
-  public enum LinkType {
-    /** Unspecified link type. */
-    LINK_TYPE_UNSPECIFIED, // = 0
-    /** Direct physical connection. */
-    LINK_TYPE_DIRECT, // = 1
-    /** Connection with local routing/switching. */
-    LINK_TYPE_MULTI_HOP, // = 2
-    /** Connection overlayed over publicly routed Internet. */
-    LINK_TYPE_OPEN_NET, // = 3
-  }
-
-  public static class EpicAuths {
-    private final byte[] authPhvf;
-    private final byte[] authLhvf;
-
-    private EpicAuths(Daemon.EpicAuths epicAuths) {
-      this.authPhvf = epicAuths.getAuthPhvf().toByteArray();
-      this.authLhvf = epicAuths.getAuthLhvf().toByteArray();
-    }
-
-    /**
-     * @return AuthPHVF is the authenticator use to calculate the PHVF.
-     */
-    public byte[] getAuthPhvf() {
-      return authPhvf;
-    }
-
-    /**
-     * @return AuthLHVF is the authenticator use to calculate the LHVF.
-     */
-    public byte[] getAuthLhvf() {
-      return authLhvf;
-    }
-  }
-
-  public static class Interface {
-    private final String address;
-
-    private Interface(Daemon.Interface inter) {
-      this.address = inter.getAddress().getAddress();
-    }
-
-    /**
-     * @return Underlay address to exit through the interface.
-     */
-    public String getAddress() {
-      return address;
-    }
-  }
-
-  public static class PathInterface {
-    private final long isdAs;
-
-    private final long id;
-
-    private PathInterface(Daemon.PathInterface pathInterface) {
-      this.isdAs = pathInterface.getIsdAs();
-      this.id = pathInterface.getId();
-    }
-
-    /**
-     * @return ISD-AS the interface belongs to.
-     */
-    public long getIsdAs() {
-      return isdAs;
-    }
-
-    /**
-     * @return ID of the interface in the AS.
-     */
-    public long getId() {
-      return id;
-    }
-  }
-
-  public static class GeoCoordinates {
-    private final float latitude;
-    private final float longitude;
-    private final String address;
-
-    private GeoCoordinates(Daemon.GeoCoordinates geoCoordinates) {
-      this.latitude = geoCoordinates.getLatitude();
-      this.longitude = geoCoordinates.getLongitude();
-      this.address = geoCoordinates.getAddress();
-    }
-
-    /**
-     * @return Latitude of the geographic coordinate, in the WGS 84 datum.
-     */
-    public float getLatitude() {
-      return latitude;
-    }
-
-    /**
-     * @return Longitude of the geographic coordinate, in the WGS 84 datum.
-     */
-    public float getLongitude() {
-      return longitude;
-    }
-
-    /**
-     * @return Civic address of the location.
-     */
-    public String getAddress() {
-      return address;
-    }
+  public PathMetadata getMetadata() {
+    return metadata;
   }
 }

--- a/src/main/java/org/scion/jpan/ResponsePath.java
+++ b/src/main/java/org/scion/jpan/ResponsePath.java
@@ -22,6 +22,8 @@ import java.net.InetSocketAddress;
  * ISD/AS, IP and port of the local host. This is mostly for convenience to avoid looking up this
  * information, but it also ensures that the return packet header contains the exact information
  * sent/expected by the client.
+ *
+ * <p>A ResponsePath is immutable and thus thread safe.
  */
 public class ResponsePath extends Path {
 
@@ -30,6 +32,7 @@ public class ResponsePath extends Path {
   private final long srcIsdAs;
   private final InetAddress srcAddress;
   private final int srcPort;
+  private final byte[] pathRaw;
 
   public static ResponsePath create(
       byte[] rawPath,
@@ -53,11 +56,12 @@ public class ResponsePath extends Path {
       InetAddress dstIP,
       int dstPort,
       InetSocketAddress firstHopAddress) {
-    super(rawPath, dstIsdAs, dstIP, dstPort);
+    super(dstIsdAs, dstIP, dstPort);
     this.firstHopAddress = firstHopAddress;
     this.srcIsdAs = srcIsdAs;
     this.srcAddress = srcIP;
     this.srcPort = srcPort;
+    this.pathRaw = rawPath;
   }
 
   @Override
@@ -75,6 +79,11 @@ public class ResponsePath extends Path {
 
   public int getLocalPort() {
     return srcPort;
+  }
+
+  @Override
+  public byte[] getRawPath() {
+    return pathRaw;
   }
 
   @Override

--- a/src/main/java/org/scion/jpan/ResponsePath.java
+++ b/src/main/java/org/scion/jpan/ResponsePath.java
@@ -25,16 +25,9 @@ import java.net.InetSocketAddress;
  *
  * <p>A ResponsePath is immutable and thus thread safe.
  */
-public class ResponsePath extends Path {
+public interface ResponsePath extends Path {
 
-  private final InetSocketAddress firstHopAddress;
-  // The ResponsePath gets source information from the incoming packet.
-  private final long srcIsdAs;
-  private final InetAddress srcAddress;
-  private final int srcPort;
-  private final byte[] pathRaw;
-
-  public static ResponsePath create(
+  static ResponsePath create(
       byte[] rawPath,
       long srcIsdAs,
       InetAddress srcIP,
@@ -43,61 +36,13 @@ public class ResponsePath extends Path {
       InetAddress dstIP,
       int dstPort,
       InetSocketAddress firstHopAddress) {
-    return new ResponsePath(
+    return ResponsePathImpl.create(
         rawPath, srcIsdAs, srcIP, srcPort, dstIsdAs, dstIP, dstPort, firstHopAddress);
   }
 
-  private ResponsePath(
-      byte[] rawPath,
-      long srcIsdAs,
-      InetAddress srcIP,
-      int srcPort,
-      long dstIsdAs,
-      InetAddress dstIP,
-      int dstPort,
-      InetSocketAddress firstHopAddress) {
-    super(dstIsdAs, dstIP, dstPort);
-    this.firstHopAddress = firstHopAddress;
-    this.srcIsdAs = srcIsdAs;
-    this.srcAddress = srcIP;
-    this.srcPort = srcPort;
-    this.pathRaw = rawPath;
-  }
+  long getLocalIsdAs();
 
-  @Override
-  public InetSocketAddress getFirstHopAddress() {
-    return firstHopAddress;
-  }
+  InetAddress getLocalAddress();
 
-  public long getLocalIsdAs() {
-    return srcIsdAs;
-  }
-
-  public InetAddress getLocalAddress() {
-    return srcAddress;
-  }
-
-  public int getLocalPort() {
-    return srcPort;
-  }
-
-  @Override
-  public byte[] getRawPath() {
-    return pathRaw;
-  }
-
-  @Override
-  public String toString() {
-    return "ResponsePath{"
-        + super.toString()
-        + ", firstHopAddress="
-        + firstHopAddress
-        + ", localIsdAs="
-        + srcIsdAs
-        + ", localAddress="
-        + srcAddress
-        + ", localPort="
-        + srcPort
-        + '}';
-  }
+  int getLocalPort();
 }

--- a/src/main/java/org/scion/jpan/ResponsePathImpl.java
+++ b/src/main/java/org/scion/jpan/ResponsePathImpl.java
@@ -1,0 +1,103 @@
+// Copyright 2023 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion.jpan;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+/**
+ * A ResponsePath is created/returned when receiving a packet. Besides being a Path, it contains
+ * ISD/AS, IP and port of the local host. This is mostly for convenience to avoid looking up this
+ * information, but it also ensures that the return packet header contains the exact information
+ * sent/expected by the client.
+ *
+ * <p>A ResponsePath is immutable and thus thread safe.
+ */
+class ResponsePathImpl extends PathImpl implements ResponsePath {
+
+  private final InetSocketAddress firstHopAddress;
+  // The ResponsePath gets source information from the incoming packet.
+  private final long srcIsdAs;
+  private final InetAddress srcAddress;
+  private final int srcPort;
+  private final byte[] pathRaw;
+
+  public static ResponsePathImpl create(
+      byte[] rawPath,
+      long srcIsdAs,
+      InetAddress srcIP,
+      int srcPort,
+      long dstIsdAs,
+      InetAddress dstIP,
+      int dstPort,
+      InetSocketAddress firstHopAddress) {
+    return new ResponsePathImpl(
+        rawPath, srcIsdAs, srcIP, srcPort, dstIsdAs, dstIP, dstPort, firstHopAddress);
+  }
+
+  private ResponsePathImpl(
+      byte[] rawPath,
+      long srcIsdAs,
+      InetAddress srcIP,
+      int srcPort,
+      long dstIsdAs,
+      InetAddress dstIP,
+      int dstPort,
+      InetSocketAddress firstHopAddress) {
+    super(dstIsdAs, dstIP, dstPort);
+    this.firstHopAddress = firstHopAddress;
+    this.srcIsdAs = srcIsdAs;
+    this.srcAddress = srcIP;
+    this.srcPort = srcPort;
+    this.pathRaw = rawPath;
+  }
+
+  @Override
+  public InetSocketAddress getFirstHopAddress() {
+    return firstHopAddress;
+  }
+
+  public long getLocalIsdAs() {
+    return srcIsdAs;
+  }
+
+  public InetAddress getLocalAddress() {
+    return srcAddress;
+  }
+
+  public int getLocalPort() {
+    return srcPort;
+  }
+
+  @Override
+  public byte[] getRawPath() {
+    return pathRaw;
+  }
+
+  @Override
+  public String toString() {
+    return "ResponsePath{"
+        + super.toString()
+        + ", firstHopAddress="
+        + firstHopAddress
+        + ", localIsdAs="
+        + srcIsdAs
+        + ", localAddress="
+        + srcAddress
+        + ", localPort="
+        + srcPort
+        + '}';
+  }
+}

--- a/src/main/java/org/scion/jpan/ScionDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramChannel.java
@@ -89,11 +89,11 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
       throw new IllegalArgumentException("Address must be of type InetSocketAddress.");
     }
     if (destination instanceof Path) {
-      return sendPath(srcBuffer, (Path) destination);
+      return send(srcBuffer, (Path) destination);
     }
     InetSocketAddress dst = (InetSocketAddress) destination;
-    Path path = getPathPolicy().filter(getOrCreateService().getPaths(dst));
-    return sendPath(srcBuffer, path);
+    Path path = getOrCreateService().lookupAndGetPath(dst, getPathPolicy());
+    return send(srcBuffer, path);
   }
 
   /**
@@ -108,7 +108,7 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
    *     cannot be resolved to an ISD/AS.
    * @see java.nio.channels.DatagramChannel#send(ByteBuffer, SocketAddress)
    */
-  public int sendPath(ByteBuffer srcBuffer, Path path) throws IOException {
+  public int send(ByteBuffer srcBuffer, Path path) throws IOException {
     writeLock().lock();
     try {
       ByteBuffer buffer = getBufferSend(srcBuffer.remaining());
@@ -168,7 +168,7 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
     try {
       checkOpen();
       checkConnected(true);
-      Path path = getRemoteAddress();
+      Path path = getConnectionPath();
 
       ByteBuffer buffer = getBufferSend(src.remaining());
       int len = src.remaining();

--- a/src/main/java/org/scion/jpan/ScionDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramChannel.java
@@ -115,13 +115,15 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
       // + 8 for UDP overlay header length
       checkPathAndBuildHeader(
           buffer, path, srcBuffer.remaining() + 8, InternalConstants.HdrTypes.UDP);
+      int headerSize = buffer.position();
       try {
         buffer.put(srcBuffer);
       } catch (BufferOverflowException e) {
         throw new IOException("Packet is larger than max send buffer size.");
       }
       buffer.flip();
-      return sendRaw(buffer, path);
+      int size = sendRaw(buffer, path);
+      return size - headerSize;
     } finally {
       writeLock().unlock();
     }

--- a/src/main/java/org/scion/jpan/ScionDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramChannel.java
@@ -121,7 +121,7 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
         throw new IOException("Packet is larger than max send buffer size.");
       }
       buffer.flip();
-      return sendRaw(buffer, path.getFirstHopAddress(), path);
+      return sendRaw(buffer, path);
     } finally {
       writeLock().unlock();
     }
@@ -175,7 +175,7 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
       buffer.put(src);
       buffer.flip();
 
-      int sent = sendRaw(buffer, path.getFirstHopAddress(), path);
+      int sent = sendRaw(buffer, path);
       if (sent < buffer.limit() || buffer.remaining() > 0) {
         throw new ScionException("Failed to send all data.");
       }

--- a/src/main/java/org/scion/jpan/ScionDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramChannel.java
@@ -169,11 +169,11 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
       ByteBuffer buffer = getBufferSend(src.remaining());
       int len = src.remaining();
       // + 8 for UDP overlay header length
-      checkPathAndBuildHeader(buffer, getConnectionPath(), len + 8, InternalConstants.HdrTypes.UDP);
+      checkPathAndBuildHeader(buffer, getRemoteAddress(), len + 8, InternalConstants.HdrTypes.UDP);
       buffer.put(src);
       buffer.flip();
 
-      int sent = sendRaw(buffer, getConnectionPath().getFirstHopAddress(), getConnectionPath());
+      int sent = sendRaw(buffer, getRemoteAddress().getFirstHopAddress(), getRemoteAddress());
       if (sent < buffer.limit() || buffer.remaining() > 0) {
         throw new ScionException("Failed to send all data.");
       }

--- a/src/main/java/org/scion/jpan/ScionDatagramSocket.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramSocket.java
@@ -290,13 +290,13 @@ public class ScionDatagramSocket extends java.net.DatagramSocket {
 
       Path path;
       if (channel.isConnected()) {
-        path = channel.getRemoteAddress();
+        path = channel.getConnectionPath();
       } else {
         InetSocketAddress addr = (InetSocketAddress) packet.getSocketAddress();
         synchronized (pathCache) {
           path = pathCache.get(addr);
           if (path == null) {
-            path = channel.getPathPolicy().filter(channel.getOrCreateService2().getPaths(addr));
+            path = channel.getOrCreateService().lookupAndGetPath(addr, channel.getPathPolicy());
           } else if (path instanceof RequestPath
               && ((RequestPath) path).getDetails().getExpiration()
                   > Instant.now().getEpochSecond()) {

--- a/src/main/java/org/scion/jpan/ScionDatagramSocket.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramSocket.java
@@ -533,7 +533,9 @@ public class ScionDatagramSocket extends java.net.DatagramSocket {
    *
    * @return the current Path or `null` if not path is connected.
    * @see ScionDatagramChannel#getConnectionPath()
+   * @deprecated Please use getRemoteAddress() instead
    */
+  @Deprecated
   public RequestPath getConnectionPath() {
     return (RequestPath) channel.getConnectionPath();
   }

--- a/src/main/java/org/scion/jpan/ScionDatagramSocket.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramSocket.java
@@ -290,7 +290,7 @@ public class ScionDatagramSocket extends java.net.DatagramSocket {
 
       Path path;
       if (channel.isConnected()) {
-        path = channel.getConnectionPath();
+        path = channel.getRemoteAddress();
       } else {
         InetSocketAddress addr = (InetSocketAddress) packet.getSocketAddress();
         synchronized (pathCache) {

--- a/src/main/java/org/scion/jpan/ScionDatagramSocket.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramSocket.java
@@ -298,7 +298,7 @@ public class ScionDatagramSocket extends java.net.DatagramSocket {
           if (path == null) {
             path = channel.getPathPolicy().filter(channel.getOrCreateService2().getPaths(addr));
           } else if (path instanceof RequestPath
-              && ((RequestPath) path).getMetadata().getExpiration()
+              && ((RequestPath) path).getDetails().getExpiration()
                   > Instant.now().getEpochSecond()) {
             // check expiration only for RequestPaths
             RequestPath request = (RequestPath) path;

--- a/src/main/java/org/scion/jpan/ScionDatagramSocket.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramSocket.java
@@ -298,7 +298,8 @@ public class ScionDatagramSocket extends java.net.DatagramSocket {
           if (path == null) {
             path = channel.getPathPolicy().filter(channel.getOrCreateService2().getPaths(addr));
           } else if (path instanceof RequestPath
-              && ((RequestPath) path).getExpiration() > Instant.now().getEpochSecond()) {
+              && ((RequestPath) path).getMetadata().getExpiration()
+                  > Instant.now().getEpochSecond()) {
             // check expiration only for RequestPaths
             RequestPath request = (RequestPath) path;
             path = channel.getPathPolicy().filter(channel.getOrCreateService2().getPaths(request));

--- a/src/main/java/org/scion/jpan/ScionService.java
+++ b/src/main/java/org/scion/jpan/ScionService.java
@@ -331,7 +331,7 @@ public class ScionService {
    * @return All paths returned by the path service.
    */
   public List<RequestPath> getPaths(RequestPath path) {
-    return getPaths(path.getIsdAs(), path.getRemoteAddress(), path.getRemotePort());
+    return getPaths(path.getRemoteIsdAs(), path.getRemoteAddress(), path.getRemotePort());
   }
 
   /**

--- a/src/main/java/org/scion/jpan/ScionService.java
+++ b/src/main/java/org/scion/jpan/ScionService.java
@@ -33,6 +33,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -554,5 +555,22 @@ public class ScionService {
         throw new ScionRuntimeException(e);
       }
     }
+  }
+
+  /**
+   * @param path RequestPath that may need refreshing
+   * @param pathPolicy PathPolicy for selecting a new path when required
+   * @param expiryMargin Expiry margin, i.e. a path is considered "expired" if expiry is less than
+   *     expiryMargin seconds away.
+   * @return `true` if the path was updated, otherwise `false`.
+   */
+  synchronized boolean refreshPath(RequestPath path, PathPolicy pathPolicy, int expiryMargin) {
+    if (Instant.now().getEpochSecond() + expiryMargin <= path.getDetails().getExpiration()) {
+      return false;
+    }
+    // expired, get new path
+    RequestPath newPath = pathPolicy.filter(getPaths(path));
+    path.setDetails(newPath.getDetails());
+    return true;
   }
 }

--- a/src/main/java/org/scion/jpan/ScionUtil.java
+++ b/src/main/java/org/scion/jpan/ScionUtil.java
@@ -132,15 +132,15 @@ public class ScionUtil {
    * @return ISD/AS codes and border outer interface IDs along the path.
    */
   public static String toStringPath(RequestPath path) {
-    PathDetails meta = path.getDetails();
-    if (meta.getInterfacesList().isEmpty()) {
+    PathDetails details = path.getDetails();
+    if (details.getInterfacesList().isEmpty()) {
       return "[]";
     }
     StringBuilder sb = new StringBuilder();
     sb.append("[");
-    int nInterfcaces = meta.getInterfacesList().size();
+    int nInterfcaces = details.getInterfacesList().size();
     for (int i = 0; i < nInterfcaces; i++) {
-      PathDetails.PathInterface pIf = meta.getInterfacesList().get(i);
+      PathDetails.PathInterface pIf = details.getInterfacesList().get(i);
       if (i % 2 == 0) {
         sb.append(ScionUtil.toStringIA(pIf.getIsdAs())).append(" ");
         sb.append(pIf.getId()).append(">");
@@ -148,7 +148,7 @@ public class ScionUtil {
         sb.append(pIf.getId()).append(" ");
       }
     }
-    sb.append(ScionUtil.toStringIA(meta.getInterfacesList().get(nInterfcaces - 1).getIsdAs()));
+    sb.append(ScionUtil.toStringIA(details.getInterfacesList().get(nInterfcaces - 1).getIsdAs()));
     sb.append("]");
     return sb.toString();
   }

--- a/src/main/java/org/scion/jpan/ScionUtil.java
+++ b/src/main/java/org/scion/jpan/ScionUtil.java
@@ -132,14 +132,15 @@ public class ScionUtil {
    * @return ISD/AS codes and border outer interface IDs along the path.
    */
   public static String toStringPath(RequestPath path) {
-    if (path.getInterfacesList().isEmpty()) {
+    PathMetadata meta = path.getMetadata();
+    if (meta.getInterfacesList().isEmpty()) {
       return "[]";
     }
     StringBuilder sb = new StringBuilder();
     sb.append("[");
-    int nInterfcaces = path.getInterfacesList().size();
+    int nInterfcaces = meta.getInterfacesList().size();
     for (int i = 0; i < nInterfcaces; i++) {
-      RequestPath.PathInterface pIf = path.getInterfacesList().get(i);
+      PathMetadata.PathInterface pIf = meta.getInterfacesList().get(i);
       if (i % 2 == 0) {
         sb.append(ScionUtil.toStringIA(pIf.getIsdAs())).append(" ");
         sb.append(pIf.getId()).append(">");
@@ -147,7 +148,7 @@ public class ScionUtil {
         sb.append(pIf.getId()).append(" ");
       }
     }
-    sb.append(ScionUtil.toStringIA(path.getInterfacesList().get(nInterfcaces - 1).getIsdAs()));
+    sb.append(ScionUtil.toStringIA(meta.getInterfacesList().get(nInterfcaces - 1).getIsdAs()));
     sb.append("]");
     return sb.toString();
   }

--- a/src/main/java/org/scion/jpan/ScionUtil.java
+++ b/src/main/java/org/scion/jpan/ScionUtil.java
@@ -132,7 +132,7 @@ public class ScionUtil {
    * @return ISD/AS codes and border outer interface IDs along the path.
    */
   public static String toStringPath(RequestPath path) {
-    PathMetadata meta = path.getMetadata();
+    PathDetails meta = path.getDetails();
     if (meta.getInterfacesList().isEmpty()) {
       return "[]";
     }
@@ -140,7 +140,7 @@ public class ScionUtil {
     sb.append("[");
     int nInterfcaces = meta.getInterfacesList().size();
     for (int i = 0; i < nInterfcaces; i++) {
-      PathMetadata.PathInterface pIf = meta.getInterfacesList().get(i);
+      PathDetails.PathInterface pIf = meta.getInterfacesList().get(i);
       if (i % 2 == 0) {
         sb.append(ScionUtil.toStringIA(pIf.getIsdAs())).append(" ");
         sb.append(pIf.getId()).append(">");

--- a/src/main/java/org/scion/jpan/ScmpChannel.java
+++ b/src/main/java/org/scion/jpan/ScmpChannel.java
@@ -229,7 +229,7 @@ public class ScmpChannel implements AutoCloseable {
             buffer, Scmp.Type.INFO_128, localPort, request.getSequenceNumber(), request.getData());
         buffer.flip();
         request.setSizeSent(buffer.remaining());
-        sendRaw(buffer, path.getFirstHopAddress());
+        sendRaw(buffer, path);
 
         int sizeReceived = receive(request);
         request.setSizeReceived(sizeReceived);
@@ -261,7 +261,7 @@ public class ScmpChannel implements AutoCloseable {
         int posPath = ScionHeaderParser.extractPathHeaderPosition(buffer);
         buffer.put(posPath + node.posHopFlags, node.hopFlags);
 
-        sendRaw(buffer, path.getFirstHopAddress());
+        sendRaw(buffer, path);
 
         receive(request);
         return request;
@@ -356,10 +356,10 @@ public class ScmpChannel implements AutoCloseable {
                 buffer, Scmp.Type.INFO_129, port, msg.getSequenceNumber(), msg.getData());
             buffer.flip();
             msg.setSizeSent(buffer.remaining());
-            sendRaw(buffer, path.getFirstHopAddress());
-            log.info("Responded to SCMP {} from {}", type, path.getRemoteAddress());
+            sendRaw(buffer, path);
+            log.info("Responded to SCMP {} from {}", type, path.getAddress());
           } else {
-            log.info("Dropped SCMP message with type {} from {}", type, path.getRemoteAddress());
+            log.info("Dropped SCMP message with type {} from {}", type, path.getAddress());
           }
         }
       } finally {

--- a/src/main/java/org/scion/jpan/ScmpChannel.java
+++ b/src/main/java/org/scion/jpan/ScmpChannel.java
@@ -407,7 +407,7 @@ public class ScmpChannel implements AutoCloseable {
     return channel.getLocalAddress();
   }
 
-  public InetSocketAddress getRemoteAddress() throws IOException {
+  public RequestPath getRemoteAddress() throws IOException {
     return channel.getRemoteAddress();
   }
 

--- a/src/main/java/org/scion/jpan/ScmpChannel.java
+++ b/src/main/java/org/scion/jpan/ScmpChannel.java
@@ -357,9 +357,9 @@ public class ScmpChannel implements AutoCloseable {
             buffer.flip();
             msg.setSizeSent(buffer.remaining());
             sendRaw(buffer, path);
-            log.info("Responded to SCMP {} from {}", type, path.getAddress());
+            log.info("Responded to SCMP {} from {}", type, path.getRemoteAddress());
           } else {
-            log.info("Dropped SCMP message with type {} from {}", type, path.getAddress());
+            log.info("Dropped SCMP message with type {} from {}", type, path.getRemoteAddress());
           }
         }
       } finally {
@@ -409,7 +409,7 @@ public class ScmpChannel implements AutoCloseable {
     return channel.getLocalAddress();
   }
 
-  public RequestPath getRemoteAddress() throws IOException {
+  public InetSocketAddress getRemoteAddress() throws IOException {
     return channel.getRemoteAddress();
   }
 

--- a/src/main/java/org/scion/jpan/ScmpChannel.java
+++ b/src/main/java/org/scion/jpan/ScmpChannel.java
@@ -398,7 +398,9 @@ public class ScmpChannel implements AutoCloseable {
    *
    * @return the current Path
    * @see ScionDatagramChannel#getConnectionPath()
+   * @deprecated Please use getRemoteAddress() instead
    */
+  @Deprecated
   public RequestPath getConnectionPath() {
     return (RequestPath) channel.getConnectionPath();
   }

--- a/src/test/java/org/scion/jpan/api/DatagramChannelApiServerTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelApiServerTest.java
@@ -85,9 +85,8 @@ class DatagramChannelApiServerTest {
               new byte[4],
               1,
               new InetSocketAddress("127.0.0.1", 1));
-      Path p2 = channel.send(ByteBuffer.allocate(0), path);
+      channel.send(ByteBuffer.allocate(0), path);
       assertNull(channel.getService());
-      assertEquals(path, p2);
     }
   }
 

--- a/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
@@ -403,6 +403,17 @@ class DatagramChannelApiTest {
   }
 
   @Test
+  void send_bufferSize() throws IOException {
+    try (ScionDatagramChannel channel = ScionDatagramChannel.open()) {
+      int size0 = channel.send(ByteBuffer.allocate(0), ExamplePacket.PATH);
+      assertEquals(0, size0);
+
+      int size100 = channel.send(ByteBuffer.wrap(new byte[100]), ExamplePacket.PATH);
+      assertEquals(100, size100);
+    }
+  }
+
+  @Test
   void send_bufferTooLarge() {
     RequestPath addr = ExamplePacket.PATH;
     ByteBuffer buffer = ByteBuffer.allocate(65440);

--- a/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
@@ -473,8 +473,9 @@ class DatagramChannelApiTest {
           ByteBuffer sendBuf = ByteBuffer.wrap(PingPongChannelHelper.MSG.getBytes());
           try {
             RequestPath newPath = (RequestPath) channel.send(sendBuf, expiredPath);
-            assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
+            assertTrue(
+                newPath.getMetadata().getExpiration() > expiredPath.getMetadata().getExpiration());
+            assertTrue(Instant.now().getEpochSecond() < newPath.getMetadata().getExpiration());
             assertNull(channel.getConnectionPath());
           } catch (IOException e) {
             throw new RuntimeException(e);
@@ -491,8 +492,9 @@ class DatagramChannelApiTest {
           ByteBuffer sendBuf = ByteBuffer.wrap(PingPongChannelHelper.MSG.getBytes());
           try {
             RequestPath newPath = (RequestPath) channel.send(sendBuf, expiredPath);
-            assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
+            assertTrue(
+                newPath.getMetadata().getExpiration() > expiredPath.getMetadata().getExpiration());
+            assertTrue(Instant.now().getEpochSecond() < newPath.getMetadata().getExpiration());
             assertEquals(newPath, channel.getConnectionPath());
           } catch (IOException e) {
             throw new RuntimeException(e);
@@ -510,8 +512,9 @@ class DatagramChannelApiTest {
           try {
             channel.write(sendBuf);
             RequestPath newPath = (RequestPath) channel.getConnectionPath();
-            assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
+            assertTrue(
+                newPath.getMetadata().getExpiration() > expiredPath.getMetadata().getExpiration());
+            assertTrue(Instant.now().getEpochSecond() < newPath.getMetadata().getExpiration());
           } catch (IOException e) {
             throw new RuntimeException(e);
           }
@@ -552,7 +555,7 @@ class DatagramChannelApiTest {
             basePath.getRemoteAddress(),
             basePath.getRemotePort(),
             basePath.getFirstHopAddress());
-    assertTrue(Instant.now().getEpochSecond() > expiredPath.getExpiration());
+    assertTrue(Instant.now().getEpochSecond() > expiredPath.getMetadata().getExpiration());
     return expiredPath;
   }
 

--- a/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
@@ -526,7 +526,7 @@ class DatagramChannelApiTest {
           ByteBuffer sendBuf = ByteBuffer.wrap(PingPongChannelHelper.MSG.getBytes());
           try {
             channel.write(sendBuf);
-            RequestPath newPath = channel.getRemoteAddress();
+            RequestPath newPath = channel.getConnectionPath();
             assertTrue(
                 newPath.getDetails().getExpiration() > expiredPath.getDetails().getExpiration());
             assertTrue(Instant.now().getEpochSecond() < newPath.getDetails().getExpiration());

--- a/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
@@ -133,7 +133,7 @@ class DatagramChannelApiTest {
       InetSocketAddress local = channel.getLocalAddress();
       assertTrue(local.getAddress().isAnyLocalAddress());
       // double check that we used a responsePath
-      assertNull(channel.getConnectionPath());
+      assertNull(channel.getRemoteAddress());
     }
   }
 
@@ -476,7 +476,7 @@ class DatagramChannelApiTest {
             assertTrue(
                 newPath.getMetadata().getExpiration() > expiredPath.getMetadata().getExpiration());
             assertTrue(Instant.now().getEpochSecond() < newPath.getMetadata().getExpiration());
-            assertNull(channel.getConnectionPath());
+            assertNull(channel.getRemoteAddress());
           } catch (IOException e) {
             throw new RuntimeException(e);
           }
@@ -495,7 +495,7 @@ class DatagramChannelApiTest {
             assertTrue(
                 newPath.getMetadata().getExpiration() > expiredPath.getMetadata().getExpiration());
             assertTrue(Instant.now().getEpochSecond() < newPath.getMetadata().getExpiration());
-            assertEquals(newPath, channel.getConnectionPath());
+            assertEquals(newPath, channel.getRemoteAddress());
           } catch (IOException e) {
             throw new RuntimeException(e);
           }
@@ -511,7 +511,7 @@ class DatagramChannelApiTest {
           ByteBuffer sendBuf = ByteBuffer.wrap(PingPongChannelHelper.MSG.getBytes());
           try {
             channel.write(sendBuf);
-            RequestPath newPath = (RequestPath) channel.getConnectionPath();
+            RequestPath newPath = channel.getRemoteAddress();
             assertTrue(
                 newPath.getMetadata().getExpiration() > expiredPath.getMetadata().getExpiration());
             assertTrue(Instant.now().getEpochSecond() < newPath.getMetadata().getExpiration());
@@ -564,22 +564,22 @@ class DatagramChannelApiTest {
     RequestPath addr = ExamplePacket.PATH;
     ByteBuffer buffer = ByteBuffer.allocate(50);
     try (ScionDatagramChannel channel = ScionDatagramChannel.open()) {
-      assertNull(channel.getConnectionPath());
+      assertNull(channel.getRemoteAddress());
       // send should NOT set a path
       channel.send(buffer, addr);
-      assertNull(channel.getConnectionPath());
+      assertNull(channel.getRemoteAddress());
 
       // connect should set a path
       channel.connect(addr);
-      assertNotNull(channel.getConnectionPath());
+      assertNotNull(channel.getRemoteAddress());
       channel.disconnect();
-      assertNull(channel.getConnectionPath());
+      assertNull(channel.getRemoteAddress());
 
       // send should NOT set a path
       if (Util.getJavaMajorVersion() >= 14) {
         // This fails because of disconnect(), see https://bugs.openjdk.org/browse/JDK-8231880
         channel.send(buffer, addr);
-        assertNull(channel.getConnectionPath());
+        assertNull(channel.getRemoteAddress());
       }
     }
   }

--- a/src/test/java/org/scion/jpan/api/DatagramChannelErrorHandlingTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelErrorHandlingTest.java
@@ -58,12 +58,12 @@ class DatagramChannelErrorHandlingTest {
       RequestPath path1 = paths.get(0);
       channel.connect(path0);
       channel.write(ByteBuffer.allocate(0));
-      assertEquals(path0, channel.getConnectionPath());
+      assertEquals(path0, channel.getRemoteAddress());
 
       // TODO Use mock instead of daemon?
       MockNetwork.returnScmpErrorOnNextPacket(Scmp.TypeCode.TYPE_5);
       channel.write(ByteBuffer.allocate(0));
-      assertEquals(path0, channel.getConnectionPath());
+      assertEquals(path0, channel.getRemoteAddress());
       assertEquals(1, scmpReceived.get());
       // mock.setSendCallback((byteBuffer,path) -> {});
 

--- a/src/test/java/org/scion/jpan/api/DatagramSocketApiTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramSocketApiTest.java
@@ -619,8 +619,8 @@ class DatagramSocketApiTest {
             socket.send(packet);
             RequestPath newPath = socket.getConnectionPath();
             assertTrue(
-                newPath.getMetadata().getExpiration() > expiredPath.getMetadata().getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getMetadata().getExpiration());
+                newPath.getDetails().getExpiration() > expiredPath.getDetails().getExpiration());
+            assertTrue(Instant.now().getEpochSecond() < newPath.getDetails().getExpiration());
             // assertNull(channel.getCurrentPath());
           } catch (IOException e) {
             throw new RuntimeException(e);
@@ -661,7 +661,7 @@ class DatagramSocketApiTest {
             basePath.getRemoteAddress(),
             basePath.getRemotePort(),
             basePath.getFirstHopAddress());
-    assertTrue(Instant.now().getEpochSecond() > expiredPath.getMetadata().getExpiration());
+    assertTrue(Instant.now().getEpochSecond() > expiredPath.getDetails().getExpiration());
     return expiredPath;
   }
 

--- a/src/test/java/org/scion/jpan/api/DatagramSocketApiTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramSocketApiTest.java
@@ -618,8 +618,9 @@ class DatagramSocketApiTest {
           try {
             socket.send(packet);
             RequestPath newPath = socket.getConnectionPath();
-            assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
+            assertTrue(
+                newPath.getMetadata().getExpiration() > expiredPath.getMetadata().getExpiration());
+            assertTrue(Instant.now().getEpochSecond() < newPath.getMetadata().getExpiration());
             // assertNull(channel.getCurrentPath());
           } catch (IOException e) {
             throw new RuntimeException(e);
@@ -660,7 +661,7 @@ class DatagramSocketApiTest {
             basePath.getRemoteAddress(),
             basePath.getRemotePort(),
             basePath.getFirstHopAddress());
-    assertTrue(Instant.now().getEpochSecond() > expiredPath.getExpiration());
+    assertTrue(Instant.now().getEpochSecond() > expiredPath.getMetadata().getExpiration());
     return expiredPath;
   }
 

--- a/src/test/java/org/scion/jpan/api/ScionServiceTest.java
+++ b/src/test/java/org/scion/jpan/api/ScionServiceTest.java
@@ -125,8 +125,8 @@ public class ScionServiceTest {
       assertEquals(dstIA, path.getRemoteIsdAs());
       assertEquals(36, path.getRawPath().length);
 
-      assertEquals("127.0.0.10:31004", path.getMetadata().getInterface().getAddress());
-      assertEquals(2, path.getMetadata().getInterfacesList().size());
+      assertEquals("127.0.0.10:31004", path.getDetails().getInterface().getAddress());
+      assertEquals(2, path.getDetails().getInterfacesList().size());
       // assertEquals(1, viewer.getInternalHopsList().size());
       // assertEquals(0, viewer.getMtu());
       // assertEquals(0, viewer.getLinkTypeList().size());

--- a/src/test/java/org/scion/jpan/api/ScionServiceTest.java
+++ b/src/test/java/org/scion/jpan/api/ScionServiceTest.java
@@ -125,8 +125,8 @@ public class ScionServiceTest {
       assertEquals(dstIA, path.getRemoteIsdAs());
       assertEquals(36, path.getRawPath().length);
 
-      assertEquals("127.0.0.10:31004", path.getInterface().getAddress());
-      assertEquals(2, path.getInterfacesList().size());
+      assertEquals("127.0.0.10:31004", path.getMetadata().getInterface().getAddress());
+      assertEquals(2, path.getMetadata().getInterfacesList().size());
       // assertEquals(1, viewer.getInternalHopsList().size());
       // assertEquals(0, viewer.getMtu());
       // assertEquals(0, viewer.getLinkTypeList().size());

--- a/src/test/java/org/scion/jpan/demo/PingPongChannelClient.java
+++ b/src/test/java/org/scion/jpan/demo/PingPongChannelClient.java
@@ -53,7 +53,7 @@ public class PingPongChannelClient {
       channel.write(sendBuf);
       println(
           "Sent via "
-              + ScionUtil.toStringPath((RequestPath) channel.getConnectionPath())
+              + ScionUtil.toStringPath((RequestPath) channel.getRemoteAddress())
               + ": "
               + msg);
 

--- a/src/test/java/org/scion/jpan/demo/ScmpEchoDemo.java
+++ b/src/test/java/org/scion/jpan/demo/ScmpEchoDemo.java
@@ -149,8 +149,8 @@ public class ScmpEchoDemo {
     // ").append(channel.getLocalAddress().getAddress().getHostAddress()).append(nl);
     sb.append("Using path:").append(nl);
     sb.append("  Hops: ").append(ScionUtil.toStringPath(path));
-    sb.append(" MTU: ").append(path.getMetadata().getMtu());
-    sb.append(" NextHop: ").append(path.getMetadata().getInterface().getAddress()).append(nl);
+    sb.append(" MTU: ").append(path.getDetails().getMtu());
+    sb.append(" NextHop: ").append(path.getDetails().getInterface().getAddress()).append(nl);
     println(sb.toString());
   }
 

--- a/src/test/java/org/scion/jpan/demo/ScmpEchoDemo.java
+++ b/src/test/java/org/scion/jpan/demo/ScmpEchoDemo.java
@@ -149,8 +149,8 @@ public class ScmpEchoDemo {
     // ").append(channel.getLocalAddress().getAddress().getHostAddress()).append(nl);
     sb.append("Using path:").append(nl);
     sb.append("  Hops: ").append(ScionUtil.toStringPath(path));
-    sb.append(" MTU: ").append(path.getMtu());
-    sb.append(" NextHop: ").append(path.getInterface().getAddress()).append(nl);
+    sb.append(" MTU: ").append(path.getMetadata().getMtu());
+    sb.append(" NextHop: ").append(path.getMetadata().getInterface().getAddress()).append(nl);
     println(sb.toString());
   }
 

--- a/src/test/java/org/scion/jpan/demo/ScmpTracerouteDemo.java
+++ b/src/test/java/org/scion/jpan/demo/ScmpTracerouteDemo.java
@@ -129,8 +129,8 @@ public class ScmpTracerouteDemo {
     // sb.append("  ").append(channel.getLocalAddress().getAddress().getHostAddress()).append(nl);
     sb.append("Using path:").append(nl);
     sb.append("  Hops: ").append(ScionUtil.toStringPath(path));
-    sb.append(" MTU: ").append(path.getMetadata().getMtu());
-    sb.append(" NextHop: ").append(path.getMetadata().getInterface().getAddress()).append(nl);
+    sb.append(" MTU: ").append(path.getDetails().getMtu());
+    sb.append(" NextHop: ").append(path.getDetails().getInterface().getAddress()).append(nl);
     println(sb.toString());
   }
 

--- a/src/test/java/org/scion/jpan/demo/ScmpTracerouteDemo.java
+++ b/src/test/java/org/scion/jpan/demo/ScmpTracerouteDemo.java
@@ -129,8 +129,8 @@ public class ScmpTracerouteDemo {
     // sb.append("  ").append(channel.getLocalAddress().getAddress().getHostAddress()).append(nl);
     sb.append("Using path:").append(nl);
     sb.append("  Hops: ").append(ScionUtil.toStringPath(path));
-    sb.append(" MTU: ").append(path.getMtu());
-    sb.append(" NextHop: ").append(path.getInterface().getAddress()).append(nl);
+    sb.append(" MTU: ").append(path.getMetadata().getMtu());
+    sb.append(" NextHop: ").append(path.getMetadata().getInterface().getAddress()).append(nl);
     println(sb.toString());
   }
 

--- a/src/test/java/org/scion/jpan/demo/ShowpathsDemo.java
+++ b/src/test/java/org/scion/jpan/demo/ShowpathsDemo.java
@@ -114,9 +114,9 @@ public class ShowpathsDemo {
               + "] Hops: "
               + ScionUtil.toStringPath(path)
               + " MTU: "
-              + path.getMetadata().getMtu()
+              + path.getDetails().getMtu()
               + " NextHop: "
-              + path.getMetadata().getInterface().getAddress()
+              + path.getDetails().getInterface().getAddress()
               + " LocalIP: "
               + localIP;
       println(sb);

--- a/src/test/java/org/scion/jpan/demo/ShowpathsDemo.java
+++ b/src/test/java/org/scion/jpan/demo/ShowpathsDemo.java
@@ -114,9 +114,9 @@ public class ShowpathsDemo {
               + "] Hops: "
               + ScionUtil.toStringPath(path)
               + " MTU: "
-              + path.getMtu()
+              + path.getMetadata().getMtu()
               + " NextHop: "
-              + path.getInterface().getAddress()
+              + path.getMetadata().getInterface().getAddress()
               + " LocalIP: "
               + localIP;
       println(sb);

--- a/src/test/java/org/scion/jpan/testutil/PingPongHelperBase.java
+++ b/src/test/java/org/scion/jpan/testutil/PingPongHelperBase.java
@@ -107,7 +107,7 @@ public class PingPongHelperBase {
       }
       InetSocketAddress serverAddress = servers[0].getLocalAddress();
       MockDNS.install(MockNetwork.TINY_SRV_ISD_AS, serverAddress.getAddress());
-      RequestPath requestPath = Scion.defaultService().getPaths(serverAddress).get(0);
+      RequestPath requestPath = Scion.defaultService().lookupAndGetPath(serverAddress, null);
 
       Thread[] clients = new Thread[nClients];
       for (int i = 0; i < clients.length; i++) {

--- a/src/test/java/org/scion/jpan/testutil/PingPongHelperBase.java
+++ b/src/test/java/org/scion/jpan/testutil/PingPongHelperBase.java
@@ -107,11 +107,11 @@ public class PingPongHelperBase {
       }
       InetSocketAddress serverAddress = servers[0].getLocalAddress();
       MockDNS.install(MockNetwork.TINY_SRV_ISD_AS, serverAddress.getAddress());
-      RequestPath scionAddress = Scion.defaultService().getPaths(serverAddress).get(0);
+      RequestPath requestPath = Scion.defaultService().getPaths(serverAddress).get(0);
 
       Thread[] clients = new Thread[nClients];
       for (int i = 0; i < clients.length; i++) {
-        clients[i] = clientFactory.create(i, scionAddress, nRounds);
+        clients[i] = clientFactory.create(i, requestPath, nRounds);
         clients[i].setName("Client-thread-" + i);
         clients[i].start();
       }


### PR DESCRIPTION
`Path` objects should be a subclass of `InetSocketAddress`inorder to be returnable from `DatagramChannel.receive()`. 

This approach (version 3) moves `Path`, `RequestPath` and `RepsonsePath` to new package-private classes `PathImpl`, `RequestPathImpl` and `RepsonsePathImpl` to new classes. For the public API we get three new interfaces `Path`, `RequestPath` and `RepsonsePath`. `PathImpl` now extends `InetSocketAddress`.

This allows paths to be returned by DatagramChannel.receive(). At the same time, a normal `Path` does not expose any `InetSocketAddress` methods to avoid confusion. In particular, as far as the user is concerned an InetSocketAddress is never a SCION address (it does not have ISD/AS), and a SCION resolved address is always a Path.

The fact that a `Path` is internally implemented as `InetSocketAddresss` is hidden from the user.

