### PR TITLE
Path-aware subclasses InetSocketAddress - v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **BREAKING CHANGE**: `DatagramChannel.receive()` returns a subclass of `InetSocketAddress` 
   [#86](https://github.com/scionproto-contrib/jpan/pull/86) 
 - Internal cleanup. [#88](https://github.com/scionproto-contrib/jpan/pull/88)
+- **BREAKING CHANGE**: Access to path details such as metadata has been moved to 
+    `Path.getDetails()`.
+  - **BREAKING CHANGE**: ScionDatagramChannel.send(buffer, path) returns 'int'.
+TODO
+- Move expiryMargin to ScionService?
+- remove ScionAddress?
+- Remove getPaths(long dstIsdAs, InetSocketAddress dstScionAddress) -< ISD + Scion address!!!
+- Remove use of getHostName() -> InetAddress!
 
 ### Fixed
 - Fixed locking and resizing of buffers. [#68](https://github.com/scionproto-contrib/jpan/pull/68)

--- a/src/main/java/org/scion/jpan/Path.java
+++ b/src/main/java/org/scion/jpan/Path.java
@@ -23,21 +23,18 @@ import java.util.Arrays;
  * <p>This class is thread safe.
  */
 public abstract class Path {
-  private final byte[] pathRaw;
+
   private final long dstIsdAs;
   private final InetAddress dstAddress;
   private final int dstPort;
 
-  protected Path(byte[] rawPath, long dstIsdAs, InetAddress dstIP, int dstPort) {
-    this.pathRaw = rawPath;
+  protected Path(long dstIsdAs, InetAddress dstIP, int dstPort) {
     this.dstIsdAs = dstIsdAs;
     this.dstAddress = dstIP;
     this.dstPort = dstPort;
   }
 
-  public byte[] getRawPath() {
-    return pathRaw;
-  }
+  public abstract byte[] getRawPath();
 
   public abstract InetSocketAddress getFirstHopAddress() throws UnknownHostException;
 

--- a/src/main/java/org/scion/jpan/PathDetails.java
+++ b/src/main/java/org/scion/jpan/PathDetails.java
@@ -1,0 +1,300 @@
+// Copyright 2023 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion.jpan;
+
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.scion.jpan.internal.IPHelper;
+import org.scion.jpan.proto.daemon.Daemon;
+
+/**
+ * PathDetails contains the raw path and meta information such as bandwidth, latency or geo
+ * coordinates. PathDetails is available from RequestPaths that are created/returned by the
+ * ScionService when requesting a new path from the control service.
+ */
+public class PathDetails {
+
+  private final Daemon.Path pathProtoc;
+  private final byte[] pathRaw;
+  // We store the first hop separately to void creating unnecessary objects.
+  private final InetSocketAddress firstHop;
+
+  static PathDetails create(Daemon.Path path, InetAddress dstIP, int dstPort) {
+    return new PathDetails(path, dstIP, dstPort);
+  }
+
+  private PathDetails(Daemon.Path path, InetAddress dstIP, int dstPort) {
+    this.pathProtoc = path;
+    this.pathRaw = path.getRaw().toByteArray();
+    if (getRawPath().length == 0) {
+      // local AS has path length 0
+      firstHop = new InetSocketAddress(dstIP, dstPort);
+    } else {
+      firstHop = getFirstHopAddress(path);
+    }
+  }
+
+  private InetSocketAddress getFirstHopAddress(Daemon.Path internalPath) {
+    try {
+      String underlayAddressString = internalPath.getInterface().getAddress().getAddress();
+      int splitIndex = underlayAddressString.indexOf(':');
+      InetAddress ip = IPHelper.toInetAddress(underlayAddressString.substring(0, splitIndex));
+      int port = Integer.parseUnsignedInt(underlayAddressString.substring(splitIndex + 1));
+      return new InetSocketAddress(ip, port);
+    } catch (UnknownHostException e) {
+      // This really should never happen, the first hop is a literal IP address.
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private Daemon.Path protoPath() {
+    if (pathProtoc == null) {
+      throw new IllegalStateException(
+          "Information is only available for paths that"
+              + " were retrieved directly from a path server.");
+    }
+    return pathProtoc;
+  }
+
+  public InetSocketAddress getFirstHopAddress() throws UnknownHostException {
+    return firstHop;
+  }
+
+  public byte[] getRawPath() {
+    return pathRaw;
+  }
+
+  /**
+   * @return Interface for exiting the local AS using this path.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public Interface getInterface() {
+    return new Interface(protoPath().getInterface());
+  }
+
+  /**
+   * @return The list of interfaces the path is composed of.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<PathInterface> getInterfacesList() {
+    return Collections.unmodifiableList(
+        protoPath().getInterfacesList().stream()
+            .map(PathInterface::new)
+            .collect(Collectors.toList()));
+  }
+
+  /**
+   * @return The maximum transmission unit (MTU) on the path.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public int getMtu() {
+    return protoPath().getMtu();
+  }
+
+  /**
+   * @return The point in time when this path expires. In seconds since UNIX epoch.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public long getExpiration() {
+    return protoPath().getExpiration().getSeconds();
+  }
+
+  /**
+   * @return Latency lists the latencies between any two consecutive interfaces. Entry i describes
+   *     the latency between interface i and i+1. Consequently, there are N-1 entries for N
+   *     interfaces. A 0-value indicates that the AS did not announce a latency for this hop.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<Integer> getLatencyList() {
+    return Collections.unmodifiableList(
+        protoPath().getLatencyList().stream()
+            .map(time -> (int) (time.getSeconds() * 1_000 + time.getNanos() / 1_000_000))
+            .collect(Collectors.toList()));
+  }
+
+  /**
+   * @return Bandwidth lists the bandwidth between any two consecutive interfaces, in Kbit/s. Entry
+   *     i describes the bandwidth between interfaces i and i+1. A 0-value indicates that the AS did
+   *     not announce a bandwidth for this hop.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<Long> getBandwidthList() {
+    return protoPath().getBandwidthList();
+  }
+
+  /**
+   * @return Geo lists the geographical position of the border routers along the path. Entry i
+   *     describes the position of the router for interface i. A 0-value indicates that the AS did
+   *     not announce a position for this router.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<GeoCoordinates> getGeoList() {
+    return Collections.unmodifiableList(
+        protoPath().getGeoList().stream().map(GeoCoordinates::new).collect(Collectors.toList()));
+  }
+
+  /**
+   * @return LinkType contains the announced link type of inter-domain links. Entry i describes the
+   *     link between interfaces 2*i and 2*i+1.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<LinkType> getLinkTypeList() {
+    return Collections.unmodifiableList(
+        protoPath().getLinkTypeList().stream()
+            .map(linkType -> LinkType.values()[linkType.getNumber()])
+            .collect(Collectors.toList()));
+  }
+
+  /**
+   * @return InternalHops lists the number of AS internal hops for the ASes on path. Entry i
+   *     describes the hop between interfaces 2*i+1 and 2*i+2 in the same AS. Consequently, there
+   *     are no entries for the first and last ASes, as these are not traversed completely by the
+   *     path.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<Integer> getInternalHopsList() {
+    return protoPath().getInternalHopsList();
+  }
+
+  /**
+   * @return Notes contains the notes added by ASes on the path, in the order of occurrence. Entry i
+   *     is the note of AS i on the path.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public List<String> getNotesList() {
+    return protoPath().getNotesList();
+  }
+
+  /**
+   * @return EpicAuths contains the EPIC authenticators used to calculate the PHVF and LHVF.
+   * @throws IllegalStateException if this is path is only a raw path
+   */
+  public EpicAuths getEpicAuths() {
+    return new EpicAuths(protoPath().getEpicAuths());
+  }
+
+  public enum LinkType {
+    /** Unspecified link type. */
+    LINK_TYPE_UNSPECIFIED, // = 0
+    /** Direct physical connection. */
+    LINK_TYPE_DIRECT, // = 1
+    /** Connection with local routing/switching. */
+    LINK_TYPE_MULTI_HOP, // = 2
+    /** Connection overlayed over publicly routed Internet. */
+    LINK_TYPE_OPEN_NET, // = 3
+  }
+
+  public static class EpicAuths {
+    private final byte[] authPhvf;
+    private final byte[] authLhvf;
+
+    private EpicAuths(Daemon.EpicAuths epicAuths) {
+      this.authPhvf = epicAuths.getAuthPhvf().toByteArray();
+      this.authLhvf = epicAuths.getAuthLhvf().toByteArray();
+    }
+
+    /**
+     * @return AuthPHVF is the authenticator use to calculate the PHVF.
+     */
+    public byte[] getAuthPhvf() {
+      return authPhvf;
+    }
+
+    /**
+     * @return AuthLHVF is the authenticator use to calculate the LHVF.
+     */
+    public byte[] getAuthLhvf() {
+      return authLhvf;
+    }
+  }
+
+  public static class Interface {
+    private final String address;
+
+    private Interface(Daemon.Interface inter) {
+      this.address = inter.getAddress().getAddress();
+    }
+
+    /**
+     * @return Underlay address to exit through the interface.
+     */
+    public String getAddress() {
+      return address;
+    }
+  }
+
+  public static class PathInterface {
+    private final long isdAs;
+
+    private final long id;
+
+    private PathInterface(Daemon.PathInterface pathInterface) {
+      this.isdAs = pathInterface.getIsdAs();
+      this.id = pathInterface.getId();
+    }
+
+    /**
+     * @return ISD-AS the interface belongs to.
+     */
+    public long getIsdAs() {
+      return isdAs;
+    }
+
+    /**
+     * @return ID of the interface in the AS.
+     */
+    public long getId() {
+      return id;
+    }
+  }
+
+  public static class GeoCoordinates {
+    private final float latitude;
+    private final float longitude;
+    private final String address;
+
+    private GeoCoordinates(Daemon.GeoCoordinates geoCoordinates) {
+      this.latitude = geoCoordinates.getLatitude();
+      this.longitude = geoCoordinates.getLongitude();
+      this.address = geoCoordinates.getAddress();
+    }
+
+    /**
+     * @return Latitude of the geographic coordinate, in the WGS 84 datum.
+     */
+    public float getLatitude() {
+      return latitude;
+    }
+
+    /**
+     * @return Longitude of the geographic coordinate, in the WGS 84 datum.
+     */
+    public float getLongitude() {
+      return longitude;
+    }
+
+    /**
+     * @return Civic address of the location.
+     */
+    public String getAddress() {
+      return address;
+    }
+  }
+}

--- a/src/main/java/org/scion/jpan/PathPolicy.java
+++ b/src/main/java/org/scion/jpan/PathPolicy.java
@@ -32,7 +32,7 @@ public interface PathPolicy {
   class MaxBandwith implements PathPolicy {
     public RequestPath filter(List<RequestPath> paths) {
       return paths.stream()
-          .max(Comparator.comparing(path -> Collections.min(path.getBandwidthList())))
+          .max(Comparator.comparing(path -> Collections.min(path.getDetails().getBandwidthList())))
           .orElseThrow(NoSuchElementException::new);
     }
   }
@@ -45,7 +45,7 @@ public interface PathPolicy {
           .min(
               Comparator.comparing(
                   path ->
-                      path.getLatencyList().stream()
+                      path.getDetails().getLatencyList().stream()
                           .mapToLong(l -> l > 0 ? l : Integer.MAX_VALUE)
                           .reduce(0, Long::sum)))
           .orElseThrow(NoSuchElementException::new);
@@ -55,7 +55,7 @@ public interface PathPolicy {
   class MinHopCount implements PathPolicy {
     public RequestPath filter(List<RequestPath> paths) {
       return paths.stream()
-          .min(Comparator.comparing(path -> path.getInternalHopsList().size()))
+          .min(Comparator.comparing(path -> path.getDetails().getInternalHopsList().size()))
           .orElseThrow(NoSuchElementException::new);
     }
   }
@@ -76,7 +76,7 @@ public interface PathPolicy {
     }
 
     private boolean checkPath(RequestPath path) {
-      for (RequestPath.PathInterface pif : path.getInterfacesList()) {
+      for (PathDetails.PathInterface pif : path.getDetails().getInterfacesList()) {
         int isd = (int) (pif.getIsdAs() >>> 48);
         if (!allowedIsds.contains(isd)) {
           return false;
@@ -102,7 +102,7 @@ public interface PathPolicy {
     }
 
     private boolean checkPath(RequestPath path) {
-      for (RequestPath.PathInterface pif : path.getInterfacesList()) {
+      for (PathDetails.PathInterface pif : path.getDetails().getInterfacesList()) {
         int isd = (int) (pif.getIsdAs() >>> 48);
         if (disallowedIsds.contains(isd)) {
           return false;

--- a/src/main/java/org/scion/jpan/RequestPath.java
+++ b/src/main/java/org/scion/jpan/RequestPath.java
@@ -14,283 +14,47 @@
 
 package org.scion.jpan;
 
-import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.scion.jpan.internal.IPHelper;
+import java.util.concurrent.atomic.AtomicReference;
 import org.scion.jpan.proto.daemon.Daemon;
 
 /**
  * A RequestPath is a Path with additional meta information such as bandwidth, latency or geo
  * coordinates. RequestPaths are created/returned by the ScionService when requesting a new path
  * from the control service.
+ *
+ * <p>A RequestPath is immutable except for an atomic reference to PathDetails (PathDetails are
+ * immutable). The reference may be updated, for example when a path expires.
  */
-public class RequestPath extends Path {
-
-  private final Daemon.Path pathProtoc;
-  // We store the first hop separately to void creating unnecessary objects.
-  private final InetSocketAddress firstHop;
+public final class RequestPath extends Path {
+  private final AtomicReference<PathDetails> details = new AtomicReference<>();
 
   static RequestPath create(Daemon.Path path, long dstIsdAs, InetAddress dstIP, int dstPort) {
     return new RequestPath(path, dstIsdAs, dstIP, dstPort);
   }
 
   private RequestPath(Daemon.Path path, long dstIsdAs, InetAddress dstIP, int dstPort) {
-    super(path.getRaw().toByteArray(), dstIsdAs, dstIP, dstPort);
-    this.pathProtoc = path;
-    if (getRawPath().length == 0) {
-      // local AS has path length 0
-      firstHop = new InetSocketAddress(getRemoteAddress(), getRemotePort());
-    } else {
-      firstHop = getFirstHopAddress(pathProtoc);
-    }
-  }
-
-  private Daemon.Path protoPath() {
-    if (pathProtoc == null) {
-      throw new IllegalStateException(
-          "Information is only available for paths that"
-              + " were retrieved directly from a path server.");
-    }
-    return pathProtoc;
+    super(dstIsdAs, dstIP, dstPort);
+    this.details.set(PathDetails.create(path, dstIP, dstPort));
   }
 
   @Override
   public InetSocketAddress getFirstHopAddress() throws UnknownHostException {
-    return firstHop;
+    return getDetails().getFirstHopAddress();
   }
 
-  private InetSocketAddress getFirstHopAddress(Daemon.Path internalPath) {
-    try {
-      String underlayAddressString = internalPath.getInterface().getAddress().getAddress();
-      int splitIndex = underlayAddressString.indexOf(':');
-      InetAddress ip = IPHelper.toInetAddress(underlayAddressString.substring(0, splitIndex));
-      int port = Integer.parseUnsignedInt(underlayAddressString.substring(splitIndex + 1));
-      return new InetSocketAddress(ip, port);
-    } catch (UnknownHostException e) {
-      // This really should never happen, the first hop is a literal IP address.
-      throw new UncheckedIOException(e);
-    }
+  @Override
+  public byte[] getRawPath() {
+    return getDetails().getRawPath();
   }
 
-  /**
-   * @return Interface for exiting the local AS using this path.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public Interface getInterface() {
-    return new Interface(protoPath().getInterface());
+  public PathDetails getDetails() {
+    return details.get();
   }
 
-  /**
-   * @return The list of interfaces the path is composed of.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<PathInterface> getInterfacesList() {
-    return Collections.unmodifiableList(
-        protoPath().getInterfacesList().stream()
-            .map(PathInterface::new)
-            .collect(Collectors.toList()));
-  }
-
-  /**
-   * @return The maximum transmission unit (MTU) on the path.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public int getMtu() {
-    return protoPath().getMtu();
-  }
-
-  /**
-   * @return The point in time when this path expires. In seconds since UNIX epoch.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public long getExpiration() {
-    return protoPath().getExpiration().getSeconds();
-  }
-
-  /**
-   * @return Latency lists the latencies between any two consecutive interfaces. Entry i describes
-   *     the latency between interface i and i+1. Consequently, there are N-1 entries for N
-   *     interfaces. A 0-value indicates that the AS did not announce a latency for this hop.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<Integer> getLatencyList() {
-    return Collections.unmodifiableList(
-        protoPath().getLatencyList().stream()
-            .map(time -> (int) (time.getSeconds() * 1_000 + time.getNanos() / 1_000_000))
-            .collect(Collectors.toList()));
-  }
-
-  /**
-   * @return Bandwidth lists the bandwidth between any two consecutive interfaces, in Kbit/s. Entry
-   *     i describes the bandwidth between interfaces i and i+1. A 0-value indicates that the AS did
-   *     not announce a bandwidth for this hop.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<Long> getBandwidthList() {
-    return protoPath().getBandwidthList();
-  }
-
-  /**
-   * @return Geo lists the geographical position of the border routers along the path. Entry i
-   *     describes the position of the router for interface i. A 0-value indicates that the AS did
-   *     not announce a position for this router.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<GeoCoordinates> getGeoList() {
-    return Collections.unmodifiableList(
-        protoPath().getGeoList().stream().map(GeoCoordinates::new).collect(Collectors.toList()));
-  }
-
-  /**
-   * @return LinkType contains the announced link type of inter-domain links. Entry i describes the
-   *     link between interfaces 2*i and 2*i+1.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<LinkType> getLinkTypeList() {
-    return Collections.unmodifiableList(
-        protoPath().getLinkTypeList().stream()
-            .map(linkType -> LinkType.values()[linkType.getNumber()])
-            .collect(Collectors.toList()));
-  }
-
-  /**
-   * @return InternalHops lists the number of AS internal hops for the ASes on path. Entry i
-   *     describes the hop between interfaces 2*i+1 and 2*i+2 in the same AS. Consequently, there
-   *     are no entries for the first and last ASes, as these are not traversed completely by the
-   *     path.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<Integer> getInternalHopsList() {
-    return protoPath().getInternalHopsList();
-  }
-
-  /**
-   * @return Notes contains the notes added by ASes on the path, in the order of occurrence. Entry i
-   *     is the note of AS i on the path.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public List<String> getNotesList() {
-    return protoPath().getNotesList();
-  }
-
-  /**
-   * @return EpicAuths contains the EPIC authenticators used to calculate the PHVF and LHVF.
-   * @throws IllegalStateException if this is path is only a raw path
-   */
-  public EpicAuths getEpicAuths() {
-    return new EpicAuths(protoPath().getEpicAuths());
-  }
-
-  public enum LinkType {
-    /** Unspecified link type. */
-    LINK_TYPE_UNSPECIFIED, // = 0
-    /** Direct physical connection. */
-    LINK_TYPE_DIRECT, // = 1
-    /** Connection with local routing/switching. */
-    LINK_TYPE_MULTI_HOP, // = 2
-    /** Connection overlayed over publicly routed Internet. */
-    LINK_TYPE_OPEN_NET, // = 3
-  }
-
-  public static class EpicAuths {
-    private final byte[] authPhvf;
-    private final byte[] authLhvf;
-
-    private EpicAuths(Daemon.EpicAuths epicAuths) {
-      this.authPhvf = epicAuths.getAuthPhvf().toByteArray();
-      this.authLhvf = epicAuths.getAuthLhvf().toByteArray();
-    }
-
-    /**
-     * @return AuthPHVF is the authenticator use to calculate the PHVF.
-     */
-    public byte[] getAuthPhvf() {
-      return authPhvf;
-    }
-
-    /**
-     * @return AuthLHVF is the authenticator use to calculate the LHVF.
-     */
-    public byte[] getAuthLhvf() {
-      return authLhvf;
-    }
-  }
-
-  public static class Interface {
-    private final String address;
-
-    private Interface(Daemon.Interface inter) {
-      this.address = inter.getAddress().getAddress();
-    }
-
-    /**
-     * @return Underlay address to exit through the interface.
-     */
-    public String getAddress() {
-      return address;
-    }
-  }
-
-  public static class PathInterface {
-    private final long isdAs;
-
-    private final long id;
-
-    private PathInterface(Daemon.PathInterface pathInterface) {
-      this.isdAs = pathInterface.getIsdAs();
-      this.id = pathInterface.getId();
-    }
-
-    /**
-     * @return ISD-AS the interface belongs to.
-     */
-    public long getIsdAs() {
-      return isdAs;
-    }
-
-    /**
-     * @return ID of the interface in the AS.
-     */
-    public long getId() {
-      return id;
-    }
-  }
-
-  public static class GeoCoordinates {
-    private final float latitude;
-    private final float longitude;
-    private final String address;
-
-    private GeoCoordinates(Daemon.GeoCoordinates geoCoordinates) {
-      this.latitude = geoCoordinates.getLatitude();
-      this.longitude = geoCoordinates.getLongitude();
-      this.address = geoCoordinates.getAddress();
-    }
-
-    /**
-     * @return Latitude of the geographic coordinate, in the WGS 84 datum.
-     */
-    public float getLatitude() {
-      return latitude;
-    }
-
-    /**
-     * @return Longitude of the geographic coordinate, in the WGS 84 datum.
-     */
-    public float getLongitude() {
-      return longitude;
-    }
-
-    /**
-     * @return Civic address of the location.
-     */
-    public String getAddress() {
-      return address;
-    }
+  void setDetails(PathDetails details) {
+    this.details.set(details);
   }
 }

--- a/src/main/java/org/scion/jpan/ResponsePath.java
+++ b/src/main/java/org/scion/jpan/ResponsePath.java
@@ -25,13 +25,14 @@ import java.net.InetSocketAddress;
  *
  * <p>A ResponsePath is immutable and thus thread safe.
  */
-public class ResponsePath extends Path {
+public final class ResponsePath extends Path {
 
   private final InetSocketAddress firstHopAddress;
   // The ResponsePath gets source information from the incoming packet.
   private final long srcIsdAs;
   private final InetAddress srcAddress;
   private final int srcPort;
+  private final byte[] pathRaw;
 
   public static ResponsePath create(
       byte[] rawPath,
@@ -55,11 +56,12 @@ public class ResponsePath extends Path {
       InetAddress dstIP,
       int dstPort,
       InetSocketAddress firstHopAddress) {
-    super(rawPath, dstIsdAs, dstIP, dstPort);
+    super(dstIsdAs, dstIP, dstPort);
     this.firstHopAddress = firstHopAddress;
     this.srcIsdAs = srcIsdAs;
     this.srcAddress = srcIP;
     this.srcPort = srcPort;
+    this.pathRaw = rawPath;
   }
 
   @Override
@@ -77,6 +79,11 @@ public class ResponsePath extends Path {
 
   public int getLocalPort() {
     return srcPort;
+  }
+
+  @Override
+  public byte[] getRawPath() {
+    return pathRaw;
   }
 
   @Override

--- a/src/main/java/org/scion/jpan/ScionDatagramSocket.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramSocket.java
@@ -296,9 +296,10 @@ public class ScionDatagramSocket extends java.net.DatagramSocket {
         synchronized (pathCache) {
           path = pathCache.get(addr);
           if (path == null) {
-            path = channel.getPathPolicy().filter(channel.getOrCreateService2().getPaths(addr));
+            path = channel.getOrCreateService().lookupAndGetPath(addr, channel.getPathPolicy());
           } else if (path instanceof RequestPath
-              && ((RequestPath) path).getExpiration() > Instant.now().getEpochSecond()) {
+              && ((RequestPath) path).getDetails().getExpiration()
+                  > Instant.now().getEpochSecond()) {
             // check expiration only for RequestPaths
             RequestPath request = (RequestPath) path;
             path = channel.getPathPolicy().filter(channel.getOrCreateService2().getPaths(request));

--- a/src/main/java/org/scion/jpan/ScionUtil.java
+++ b/src/main/java/org/scion/jpan/ScionUtil.java
@@ -132,14 +132,15 @@ public class ScionUtil {
    * @return ISD/AS codes and border outer interface IDs along the path.
    */
   public static String toStringPath(RequestPath path) {
-    if (path.getInterfacesList().isEmpty()) {
+    PathDetails details = path.getDetails();
+    if (details.getInterfacesList().isEmpty()) {
       return "[]";
     }
     StringBuilder sb = new StringBuilder();
     sb.append("[");
-    int nInterfcaces = path.getInterfacesList().size();
+    int nInterfcaces = details.getInterfacesList().size();
     for (int i = 0; i < nInterfcaces; i++) {
-      RequestPath.PathInterface pIf = path.getInterfacesList().get(i);
+      PathDetails.PathInterface pIf = details.getInterfacesList().get(i);
       if (i % 2 == 0) {
         sb.append(ScionUtil.toStringIA(pIf.getIsdAs())).append(" ");
         sb.append(pIf.getId()).append(">");
@@ -147,7 +148,7 @@ public class ScionUtil {
         sb.append(pIf.getId()).append(" ");
       }
     }
-    sb.append(ScionUtil.toStringIA(path.getInterfacesList().get(nInterfcaces - 1).getIsdAs()));
+    sb.append(ScionUtil.toStringIA(details.getInterfacesList().get(nInterfcaces - 1).getIsdAs()));
     sb.append("]");
     return sb.toString();
   }

--- a/src/main/java/org/scion/jpan/ScmpChannel.java
+++ b/src/main/java/org/scion/jpan/ScmpChannel.java
@@ -400,7 +400,7 @@ public class ScmpChannel implements AutoCloseable {
    * @see ScionDatagramChannel#getConnectionPath()
    */
   public RequestPath getConnectionPath() {
-    return (RequestPath) channel.getConnectionPath();
+    return channel.getConnectionPath();
   }
 
   public InetSocketAddress getLocalAddress() throws IOException {

--- a/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
@@ -403,6 +403,17 @@ class DatagramChannelApiTest {
   }
 
   @Test
+  void send_bufferSize() throws IOException {
+    try (ScionDatagramChannel channel = ScionDatagramChannel.open()) {
+      int size0 = channel.send(ByteBuffer.allocate(0), ExamplePacket.PATH);
+      assertEquals(0, size0);
+
+      int size100 = channel.send(ByteBuffer.wrap(new byte[100]), ExamplePacket.PATH);
+      assertEquals(100, size100);
+    }
+  }
+
+  @Test
   void send_bufferTooLarge() {
     RequestPath addr = ExamplePacket.PATH;
     ByteBuffer buffer = ByteBuffer.allocate(65440);
@@ -469,12 +480,15 @@ class DatagramChannelApiTest {
   void send_disconnected_expiredRequestPath() throws IOException {
     // Expected behavior: expired paths should be replaced transparently.
     testExpired(
-        (channel, expiredPath) -> {
+        (channel, expiringPath) -> {
           ByteBuffer sendBuf = ByteBuffer.wrap(PingPongChannelHelper.MSG.getBytes());
           try {
-            RequestPath newPath = (RequestPath) channel.send(sendBuf, expiredPath);
-            assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
+            long oldExpiration = expiringPath.getDetails().getExpiration();
+            assertTrue(Instant.now().getEpochSecond() > oldExpiration);
+            channel.send(sendBuf, expiringPath);
+            long newExpiration = expiringPath.getDetails().getExpiration();
+            assertTrue(newExpiration > oldExpiration);
+            assertTrue(Instant.now().getEpochSecond() < newExpiration);
             assertNull(channel.getConnectionPath());
           } catch (IOException e) {
             throw new RuntimeException(e);
@@ -487,13 +501,16 @@ class DatagramChannelApiTest {
   void send_connected_expiredRequestPath() throws IOException {
     // Expected behavior: expired paths should be replaced transparently.
     testExpired(
-        (channel, expiredPath) -> {
+        (channel, expiringPath) -> {
           ByteBuffer sendBuf = ByteBuffer.wrap(PingPongChannelHelper.MSG.getBytes());
           try {
-            RequestPath newPath = (RequestPath) channel.send(sendBuf, expiredPath);
-            assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
-            assertEquals(newPath, channel.getConnectionPath());
+            long oldExpiration = expiringPath.getDetails().getExpiration();
+            assertTrue(Instant.now().getEpochSecond() > oldExpiration);
+            channel.send(sendBuf, expiringPath);
+            long newExpiration = expiringPath.getDetails().getExpiration();
+            assertTrue(newExpiration > oldExpiration);
+            assertTrue(Instant.now().getEpochSecond() < newExpiration);
+            assertEquals(expiringPath, channel.getConnectionPath());
           } catch (IOException e) {
             throw new RuntimeException(e);
           }
@@ -510,8 +527,9 @@ class DatagramChannelApiTest {
           try {
             channel.write(sendBuf);
             RequestPath newPath = channel.getConnectionPath();
-            assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
+            assertTrue(
+                newPath.getDetails().getExpiration() > expiredPath.getDetails().getExpiration());
+            assertTrue(Instant.now().getEpochSecond() < newPath.getDetails().getExpiration());
           } catch (IOException e) {
             throw new RuntimeException(e);
           }
@@ -552,7 +570,7 @@ class DatagramChannelApiTest {
             basePath.getRemoteAddress(),
             basePath.getRemotePort(),
             basePath.getFirstHopAddress());
-    assertTrue(Instant.now().getEpochSecond() > expiredPath.getExpiration());
+    assertTrue(Instant.now().getEpochSecond() > expiredPath.getDetails().getExpiration());
     return expiredPath;
   }
 

--- a/src/test/java/org/scion/jpan/api/DatagramSocketApiTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramSocketApiTest.java
@@ -618,8 +618,9 @@ class DatagramSocketApiTest {
           try {
             socket.send(packet);
             RequestPath newPath = socket.getConnectionPath();
-            assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
+            assertTrue(
+                newPath.getDetails().getExpiration() > expiredPath.getDetails().getExpiration());
+            assertTrue(Instant.now().getEpochSecond() < newPath.getDetails().getExpiration());
             // assertNull(channel.getCurrentPath());
           } catch (IOException e) {
             throw new RuntimeException(e);
@@ -660,7 +661,7 @@ class DatagramSocketApiTest {
             basePath.getRemoteAddress(),
             basePath.getRemotePort(),
             basePath.getFirstHopAddress());
-    assertTrue(Instant.now().getEpochSecond() > expiredPath.getExpiration());
+    assertTrue(Instant.now().getEpochSecond() > expiredPath.getDetails().getExpiration());
     return expiredPath;
   }
 

--- a/src/test/java/org/scion/jpan/api/ScionServiceTest.java
+++ b/src/test/java/org/scion/jpan/api/ScionServiceTest.java
@@ -125,8 +125,8 @@ public class ScionServiceTest {
       assertEquals(dstIA, path.getRemoteIsdAs());
       assertEquals(36, path.getRawPath().length);
 
-      assertEquals("127.0.0.10:31004", path.getInterface().getAddress());
-      assertEquals(2, path.getInterfacesList().size());
+      assertEquals("127.0.0.10:31004", path.getDetails().getInterface().getAddress());
+      assertEquals(2, path.getDetails().getInterfacesList().size());
       // assertEquals(1, viewer.getInternalHopsList().size());
       // assertEquals(0, viewer.getMtu());
       // assertEquals(0, viewer.getLinkTypeList().size());

--- a/src/test/java/org/scion/jpan/demo/ScmpEchoDemo.java
+++ b/src/test/java/org/scion/jpan/demo/ScmpEchoDemo.java
@@ -149,8 +149,8 @@ public class ScmpEchoDemo {
     // ").append(channel.getLocalAddress().getAddress().getHostAddress()).append(nl);
     sb.append("Using path:").append(nl);
     sb.append("  Hops: ").append(ScionUtil.toStringPath(path));
-    sb.append(" MTU: ").append(path.getMtu());
-    sb.append(" NextHop: ").append(path.getInterface().getAddress()).append(nl);
+    sb.append(" MTU: ").append(path.getDetails().getMtu());
+    sb.append(" NextHop: ").append(path.getDetails().getInterface().getAddress()).append(nl);
     println(sb.toString());
   }
 

--- a/src/test/java/org/scion/jpan/demo/ScmpTracerouteDemo.java
+++ b/src/test/java/org/scion/jpan/demo/ScmpTracerouteDemo.java
@@ -129,8 +129,8 @@ public class ScmpTracerouteDemo {
     // sb.append("  ").append(channel.getLocalAddress().getAddress().getHostAddress()).append(nl);
     sb.append("Using path:").append(nl);
     sb.append("  Hops: ").append(ScionUtil.toStringPath(path));
-    sb.append(" MTU: ").append(path.getMtu());
-    sb.append(" NextHop: ").append(path.getInterface().getAddress()).append(nl);
+    sb.append(" MTU: ").append(path.getDetails().getMtu());
+    sb.append(" NextHop: ").append(path.getDetails().getInterface().getAddress()).append(nl);
     println(sb.toString());
   }
 

--- a/src/test/java/org/scion/jpan/demo/ShowpathsDemo.java
+++ b/src/test/java/org/scion/jpan/demo/ShowpathsDemo.java
@@ -114,9 +114,9 @@ public class ShowpathsDemo {
               + "] Hops: "
               + ScionUtil.toStringPath(path)
               + " MTU: "
-              + path.getMtu()
+              + path.getDetails().getMtu()
               + " NextHop: "
-              + path.getInterface().getAddress()
+              + path.getDetails().getInterface().getAddress()
               + " LocalIP: "
               + localIP;
       println(sb);

--- a/src/test/java/org/scion/jpan/testutil/PingPongHelperBase.java
+++ b/src/test/java/org/scion/jpan/testutil/PingPongHelperBase.java
@@ -107,11 +107,11 @@ public class PingPongHelperBase {
       }
       InetSocketAddress serverAddress = servers[0].getLocalAddress();
       MockDNS.install(MockNetwork.TINY_SRV_ISD_AS, serverAddress.getAddress());
-      RequestPath scionAddress = Scion.defaultService().getPaths(serverAddress).get(0);
+      RequestPath requestPath = Scion.defaultService().lookupAndGetPath(serverAddress, null);
 
       Thread[] clients = new Thread[nClients];
       for (int i = 0; i < clients.length; i++) {
-        clients[i] = clientFactory.create(i, scionAddress, nRounds);
+        clients[i] = clientFactory.create(i, requestPath, nRounds);
         clients[i].setName("Client-thread-" + i);
         clients[i].start();
       }


### PR DESCRIPTION
`DatagramChannel.receive()` should return a subclass of `InetSocketAddress` that contains ReturnPath information. 

This approach (version 4) introduces a new `ScionRetunAddress` class that extends `InetSocketAddress`.

This allows paths to be returned by `DatagramChannel.receive()`. At the same time, a normal `Path` does not expose any `InetSocketAddress` methods to avoid confusion. In particular, as far as the user is concerned an InetSocketAddress is never a SCION address (it does not have ISD/AS), and a SCION resolved address is always a Path.
