### PR TITLE
Path-aware subclasses InetSocketAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## Added
+### Added
 - SCMP echo responder [#78](https://github.com/scionproto-contrib/jpan/pull/78)
 - Maven Java executor [#80](https://github.com/scionproto-contrib/jpan/pull/80)
 - Dev environment setup hints doc [#82](https://github.com/scionproto-contrib/jpan/pull/82)
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Rename `DatagramSocket` to `ScionDatagramSopcketl` and move it to main package
   - Rename `ScionSocketOptions`  starting with `SN_` to `SCION_`
 - SCMP API changes. [#71](https://github.com/scionproto-contrib/jpan/pull/71)
+- **BREAKING CHANGE**: `DatagramChannel.receive()` returns a subclass of `InetSocketAddress` 
+  [#69](https://github.com/scionproto-contrib/jpan/pull/69) 
 
 ### Fixed
 - Fixed locking and resizing of buffers. [#68](https://github.com/scionproto-contrib/jpan/pull/68)

--- a/src/main/java/org/scion/jpan/ScionDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramChannel.java
@@ -88,6 +88,10 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
     if (!(destination instanceof InetSocketAddress)) {
       throw new IllegalArgumentException("Address must be of type InetSocketAddress.");
     }
+    if (destination instanceof ScionResponseAddress) {
+      send(srcBuffer, ((ScionResponseAddress) destination).getPath());
+      return;
+    }
     InetSocketAddress dst = (InetSocketAddress) destination;
     Path path = getPathPolicy().filter(getOrCreateService().getPaths(dst));
     send(srcBuffer, path);

--- a/src/main/java/org/scion/jpan/ScionDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramChannel.java
@@ -57,7 +57,7 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
     return super.isBlocking();
   }
 
-  public ResponsePath receive(ByteBuffer userBuffer) throws IOException {
+  public ScionResponseAddress receive(ByteBuffer userBuffer) throws IOException {
     readLock().lock();
     try {
       ByteBuffer buffer = getBufferReceive(userBuffer.capacity());
@@ -67,7 +67,7 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
       }
       ScionHeaderParser.extractUserPayload(buffer, userBuffer);
       buffer.clear();
-      return receivePath;
+      return ScionResponseAddress.from(receivePath);
     } finally {
       readLock().unlock();
     }

--- a/src/main/java/org/scion/jpan/ScionDatagramSocket.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramSocket.java
@@ -323,11 +323,12 @@ public class ScionDatagramSocket extends java.net.DatagramSocket {
     synchronized (packet) {
       ByteBuffer receiveBuffer =
           ByteBuffer.wrap(packet.getData(), packet.getOffset(), packet.getLength());
-      ResponsePath path = channel.receive(receiveBuffer);
-      if (path == null) {
+      ScionResponseAddress responseAddress = channel.receive(receiveBuffer);
+      if (responseAddress == null) {
         // timeout occurred
         throw new SocketTimeoutException();
       }
+      ResponsePath path = responseAddress.getPath();
       // TODO this is not ideal, a client may not be connected. Use getService()==null?
       if (!channel.isConnected()) {
         synchronized (pathCache) {

--- a/src/main/java/org/scion/jpan/ScionResponseAddress.java
+++ b/src/main/java/org/scion/jpan/ScionResponseAddress.java
@@ -1,0 +1,35 @@
+// Copyright 2024 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.scion.jpan;
+
+import java.net.InetSocketAddress;
+
+public class ScionResponseAddress extends InetSocketAddress {
+
+  private final ResponsePath responsePath;
+
+  public static ScionResponseAddress from(ResponsePath path) {
+    return new ScionResponseAddress(path);
+  }
+
+  private ScionResponseAddress(ResponsePath path) {
+    super(path.getRemoteAddress(), path.getRemotePort());
+    this.responsePath = path;
+  }
+
+  public ResponsePath getPath() {
+    return responsePath;
+  }
+}

--- a/src/main/java/org/scion/jpan/internal/SelectingDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/internal/SelectingDatagramChannel.java
@@ -23,6 +23,7 @@ import java.nio.channels.Selector;
 import java.util.Iterator;
 import org.scion.jpan.ResponsePath;
 import org.scion.jpan.ScionDatagramChannel;
+import org.scion.jpan.ScionResponseAddress;
 import org.scion.jpan.ScionService;
 
 /**
@@ -89,7 +90,7 @@ public class SelectingDatagramChannel extends ScionDatagramChannel {
   }
 
   @Override
-  public ResponsePath receive(ByteBuffer userBuffer) throws IOException {
+  public ScionResponseAddress receive(ByteBuffer userBuffer) throws IOException {
     readLock().lock();
     try {
       ByteBuffer buffer = getBufferReceive(userBuffer.capacity());
@@ -99,7 +100,7 @@ public class SelectingDatagramChannel extends ScionDatagramChannel {
       }
       ScionHeaderParser.extractUserPayload(buffer, userBuffer);
       buffer.clear();
-      return receivePath;
+      return ScionResponseAddress.from(receivePath);
     } finally {
       readLock().unlock();
     }

--- a/src/test/java/org/scion/jpan/api/DatagramChannelApiConcurrencyTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelApiConcurrencyTest.java
@@ -26,8 +26,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.scion.jpan.ResponsePath;
 import org.scion.jpan.ScionDatagramChannel;
+import org.scion.jpan.ScionResponseAddress;
 import org.scion.jpan.ScionService;
 import org.scion.jpan.testutil.MockDNS;
 import org.scion.jpan.testutil.MockDaemon;
@@ -128,8 +128,8 @@ class DatagramChannelApiConcurrencyTest {
           }
 
           // check that receive is responsive
-          ResponsePath path = server.receive(buffer);
-          server.send(buffer, path);
+          ScionResponseAddress responseAddress = server.receive(buffer);
+          server.send(buffer, responseAddress);
           // wait
           synchronized (receiveCount) {
             receiveCount.wait(1000);
@@ -138,7 +138,7 @@ class DatagramChannelApiConcurrencyTest {
 
           // send again to trigger 2nd receiver
           buffer.flip();
-          server.send(buffer, path);
+          server.send(buffer, responseAddress);
           // wait
           synchronized (receiveCount) {
             receiveCount.wait(1000);

--- a/src/test/java/org/scion/jpan/api/DatagramChannelApiServerTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelApiServerTest.java
@@ -104,9 +104,9 @@ class DatagramChannelApiServerTest {
     try (ScionDatagramChannel channel = ScionDatagramChannel.open(null, mock)) {
       assertNull(channel.getService());
       ByteBuffer buffer = ByteBuffer.allocate(100);
-      Path path = channel.receive(buffer);
+      ScionResponseAddress responseAddress = channel.receive(buffer);
       assertNull(channel.getService());
-      assertEquals(addr, path.getFirstHopAddress());
+      assertEquals(addr, responseAddress.getPath().getFirstHopAddress());
     }
   }
 }

--- a/src/test/java/org/scion/jpan/api/DatagramChannelMultiSendInetAddrTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelMultiSendInetAddrTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.scion.jpan.Path;
 import org.scion.jpan.ScionDatagramChannel;
+import org.scion.jpan.ScionResponseAddress;
 import org.scion.jpan.ScionService;
 import org.scion.jpan.testutil.PingPongChannelHelper;
 
@@ -56,10 +57,12 @@ class DatagramChannelMultiSendInetAddrTest {
 
     // System.out.println("CLIENT: Receiving ... (" + channel.getLocalAddress() + ")");
     ByteBuffer response = ByteBuffer.allocate(512);
-    Path address = channel.receive(response);
+    ScionResponseAddress address = channel.receive(response);
     assertNotNull(address);
-    assertEquals(serverAddress.getRemoteAddress(), address.getRemoteAddress());
-    assertEquals(serverAddress.getRemotePort(), address.getRemotePort());
+    assertEquals(serverAddress.getRemoteAddress(), address.getPath().getRemoteAddress());
+    assertEquals(serverAddress.getRemotePort(), address.getPath().getRemotePort());
+    assertEquals(serverAddress.getRemoteAddress(), address.getAddress());
+    assertEquals(serverAddress.getRemotePort(), address.getPort());
 
     response.flip();
     String pong = Charset.defaultCharset().decode(response).toString();

--- a/src/test/java/org/scion/jpan/api/DatagramChannelMultiSendPathTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelMultiSendPathTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.scion.jpan.Path;
 import org.scion.jpan.ScionDatagramChannel;
+import org.scion.jpan.ScionResponseAddress;
 import org.scion.jpan.ScionService;
 import org.scion.jpan.testutil.PingPongChannelHelper;
 
@@ -50,10 +51,12 @@ class DatagramChannelMultiSendPathTest {
 
     // System.out.println("CLIENT: Receiving ... (" + channel.getLocalAddress() + ")");
     ByteBuffer response = ByteBuffer.allocate(512);
-    Path address = channel.receive(response);
+    ScionResponseAddress address = channel.receive(response);
     assertNotNull(address);
-    assertEquals(serverAddress.getRemoteAddress(), address.getRemoteAddress());
-    assertEquals(serverAddress.getRemotePort(), address.getRemotePort());
+    assertEquals(serverAddress.getRemoteAddress(), address.getAddress());
+    assertEquals(serverAddress.getRemotePort(), address.getPort());
+    assertEquals(serverAddress.getRemoteAddress(), address.getPath().getRemoteAddress());
+    assertEquals(serverAddress.getRemotePort(), address.getPath().getRemotePort());
 
     response.flip();
     String pong = Charset.defaultCharset().decode(response).toString();

--- a/src/test/java/org/scion/jpan/api/DatagramChannelMultiWriteConnectedPathTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelMultiWriteConnectedPathTest.java
@@ -21,10 +21,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.scion.jpan.Path;
-import org.scion.jpan.RequestPath;
-import org.scion.jpan.ScionDatagramChannel;
-import org.scion.jpan.ScionService;
+import org.scion.jpan.*;
 import org.scion.jpan.testutil.PingPongChannelHelper;
 
 /** Test read()/write() operations on DatagramChannel connected with a path. */
@@ -68,7 +65,7 @@ class DatagramChannelMultiWriteConnectedPathTest {
   private void server(ScionDatagramChannel channel) throws IOException {
     ByteBuffer request = ByteBuffer.allocate(512);
     // System.out.println("SERVER: --- USER - Waiting for packet --------------------- " + i);
-    Path path = channel.receive(request);
+    ScionResponseAddress responseAddress = channel.receive(request);
 
     request.flip();
     String msg = Charset.defaultCharset().decode(request).toString();
@@ -77,6 +74,6 @@ class DatagramChannelMultiWriteConnectedPathTest {
 
     // System.out.println("SERVER: --- USER - Sending packet ---------------------- " + i);
     request.flip();
-    channel.send(request, path);
+    channel.send(request, responseAddress);
   }
 }

--- a/src/test/java/org/scion/jpan/api/DatagramChannelStreamTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelStreamTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.scion.jpan.Path;
 import org.scion.jpan.ScionDatagramChannel;
+import org.scion.jpan.ScionResponseAddress;
 import org.scion.jpan.ScionService;
 import org.scion.jpan.testutil.MockNetwork;
 import org.scion.jpan.testutil.PingPongChannelHelper;
@@ -71,11 +72,11 @@ class DatagramChannelStreamTest {
   }
 
   private static class Pair {
-    Path path;
+    ScionResponseAddress responseAddress;
     String msg;
 
-    Pair(Path path, String msg) {
-      this.path = path;
+    Pair(ScionResponseAddress responseAddress, String msg) {
+      this.responseAddress = responseAddress;
       this.msg = msg;
     }
   }
@@ -88,10 +89,10 @@ class DatagramChannelStreamTest {
     ArrayList<Pair> received = new ArrayList<>();
     for (int i = 0; i < N_BULK; i++) {
       request.clear();
-      Path returnAddress = channel.receive(request);
+      ScionResponseAddress responseAddress = channel.receive(request);
       request.flip();
       String msg = Charset.defaultCharset().decode(request).toString();
-      received.add(new Pair(returnAddress, msg));
+      received.add(new Pair(responseAddress, msg));
       assertTrue(msg.startsWith(PingPongChannelHelper.MSG), msg);
       assertTrue(PingPongChannelHelper.MSG.length() + 3 >= msg.length());
     }
@@ -105,7 +106,7 @@ class DatagramChannelStreamTest {
       request.clear();
       request.put(p.msg.getBytes());
       request.flip();
-      channel.send(request, p.path);
+      channel.send(request, p.responseAddress);
     }
   }
 }

--- a/src/test/java/org/scion/jpan/demo/PingPongChannelServer.java
+++ b/src/test/java/org/scion/jpan/demo/PingPongChannelServer.java
@@ -17,9 +17,7 @@ package org.scion.jpan.demo;
 import java.io.*;
 import java.net.*;
 import java.nio.ByteBuffer;
-import org.scion.jpan.Path;
-import org.scion.jpan.ScionDatagramChannel;
-import org.scion.jpan.ScionUtil;
+import org.scion.jpan.*;
 
 public class PingPongChannelServer {
 
@@ -54,7 +52,8 @@ public class PingPongChannelServer {
       channel.bind(SERVER_ADDRESS);
       ByteBuffer buffer = ByteBuffer.allocate(100);
       println("Waiting for packet ... ");
-      Path path = channel.receive(buffer);
+      ScionResponseAddress responseAddress = channel.receive(buffer);
+      ResponsePath path = responseAddress.getPath();
       String msg = extractMessage(buffer);
       String remoteAddress = path.getRemoteAddress() + ":" + path.getRemotePort();
       String borderRouterInterfaces = ScionUtil.toStringPath(path.getRawPath());

--- a/src/test/java/org/scion/jpan/testutil/PingPongChannelHelper.java
+++ b/src/test/java/org/scion/jpan/testutil/PingPongChannelHelper.java
@@ -159,6 +159,6 @@ public class PingPongChannelHelper extends PingPongHelperBase {
 
     request.flip();
     channel.send(request, responseAddress);
-    // System.out.println("SERVER: Sent: " + address);
+    // System.out.println("SERVER: Sent: " + responseAddress);
   }
 }

--- a/src/test/java/org/scion/jpan/testutil/PingPongChannelHelper.java
+++ b/src/test/java/org/scion/jpan/testutil/PingPongChannelHelper.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import org.scion.jpan.Path;
 import org.scion.jpan.RequestPath;
 import org.scion.jpan.ScionDatagramChannel;
+import org.scion.jpan.ScionResponseAddress;
 
 public class PingPongChannelHelper extends PingPongHelperBase {
 
@@ -136,10 +137,10 @@ public class PingPongChannelHelper extends PingPongHelperBase {
 
     // System.out.println("CLIENT: Receiving ... (" + channel.getLocalAddress() + ")");
     ByteBuffer response = ByteBuffer.allocate(512);
-    Path address = channel.receive(response);
+    ScionResponseAddress address = channel.receive(response);
     assertNotNull(address);
-    assertEquals(serverAddress.getRemoteAddress(), address.getRemoteAddress());
-    assertEquals(serverAddress.getRemotePort(), address.getRemotePort());
+    assertEquals(serverAddress.getRemoteAddress(), address.getAddress());
+    assertEquals(serverAddress.getRemotePort(), address.getPort());
 
     response.flip();
     String pong = Charset.defaultCharset().decode(response).toString();
@@ -149,7 +150,7 @@ public class PingPongChannelHelper extends PingPongHelperBase {
   public static void defaultServer(ScionDatagramChannel channel) throws IOException {
     ByteBuffer request = ByteBuffer.allocate(512);
     // System.out.println("SERVER: Receiving ... (" + channel.getLocalAddress() + ")");
-    Path address = channel.receive(request);
+    ScionResponseAddress responseAddress = channel.receive(request);
 
     request.flip();
     String msg = Charset.defaultCharset().decode(request).toString();
@@ -157,7 +158,7 @@ public class PingPongChannelHelper extends PingPongHelperBase {
     assertTrue(MSG.length() + 3 >= msg.length());
 
     request.flip();
-    channel.send(request, address);
+    channel.send(request, responseAddress);
     // System.out.println("SERVER: Sent: " + address);
   }
 }


### PR DESCRIPTION
`DatagramChannel.receive()` should return a subclass of `InetSocketAddress` that contains `ReturnPath` information. 

To do this we introduce a new `ScionReturnAddress` class that extends `InetSocketAddress`.

This allows paths to be returned by `DatagramChannel.receive()`. At the same time, a normal `Path` does not expose any `InetSocketAddress` methods to avoid confusion. In particular, as far as the user is concerned an InetSocketAddress is never a SCION address (it does not have ISD/AS), and a SCION resolved address is always a Path.