### PR TITLE
DatagramChannel.send() returns int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [#77](https://github.com/scionproto-contrib/jpan/pull/77)
 - Improved bootstrap logging [#83](https://github.com/scionproto-contrib/jpan/pull/83)
 - `DatagramChannel.send()` should return `int`.
-  [#85](https://github.com/scionproto-contrib/jpan/pull/85)
+  [#86](https://github.com/scionproto-contrib/jpan/pull/86)
 
 ## [0.1.1] - 2024-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed internal raw path parsing and IP parsing.
   [#77](https://github.com/scionproto-contrib/jpan/pull/77)
 - Improved bootstrap logging [#83](https://github.com/scionproto-contrib/jpan/pull/83)
+- `DatagramChannel.send()` should return `int`.
+  [#85](https://github.com/scionproto-contrib/jpan/pull/85)
 
 ## [0.1.1] - 2024-05-10
 

--- a/src/main/java/org/scion/jpan/ScionDatagramChannel.java
+++ b/src/main/java/org/scion/jpan/ScionDatagramChannel.java
@@ -80,11 +80,13 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
    * @param srcBuffer Data to send
    * @param destination Destination address. This should contain a host name known to the DNS so
    *     that the ISD/AS information can be retrieved.
+   * @return The number of bytes sent, see {@link java.nio.channels.DatagramChannel#send(ByteBuffer,
+   *     SocketAddress)}.
    * @throws IOException if an error occurs, e.g. if the destinationAddress is an IP address that
    *     cannot be resolved to an ISD/AS.
    * @see java.nio.channels.DatagramChannel#send(ByteBuffer, SocketAddress)
    */
-  public void send(ByteBuffer srcBuffer, SocketAddress destination) throws IOException {
+  public int send(ByteBuffer srcBuffer, SocketAddress destination) throws IOException {
     if (!(destination instanceof InetSocketAddress)) {
       throw new IllegalArgumentException("Address must be of type InetSocketAddress.");
     }
@@ -94,7 +96,7 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
     }
     InetSocketAddress dst = (InetSocketAddress) destination;
     Path path = getPathPolicy().filter(getOrCreateService().getPaths(dst));
-    send(srcBuffer, path);
+    return send(srcBuffer, path);
   }
 
   /**
@@ -103,13 +105,13 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
    * @param srcBuffer Data to send
    * @param path Path to destination. If this is a RequestPath, and it is expired, then it will
    *     automatically be replaced with a new path. Expiration of ResponsePaths is not checked
-   * @return either the path argument or a new path if the path was an expired RequestPath. Note
-   *     that ResponsePaths are not checked for expiration.
+   * @return The number of bytes sent, see {@link java.nio.channels.DatagramChannel#send(ByteBuffer,
+   *     SocketAddress)}.
    * @throws IOException if an error occurs, e.g. if the destinationAddress is an IP address that
    *     cannot be resolved to an ISD/AS.
    * @see java.nio.channels.DatagramChannel#send(ByteBuffer, SocketAddress)
    */
-  public Path send(ByteBuffer srcBuffer, Path path) throws IOException {
+  public int send(ByteBuffer srcBuffer, Path path) throws IOException {
     writeLock().lock();
     try {
       ByteBuffer buffer = getBufferSend(srcBuffer.remaining());
@@ -117,14 +119,15 @@ public class ScionDatagramChannel extends AbstractDatagramChannel<ScionDatagramC
       Path actualPath =
           checkPathAndBuildHeader(
               buffer, path, srcBuffer.remaining() + 8, InternalConstants.HdrTypes.UDP);
+      int headerSize = buffer.position();
       try {
         buffer.put(srcBuffer);
       } catch (BufferOverflowException e) {
         throw new IOException("Packet is larger than max send buffer size.");
       }
       buffer.flip();
-      sendRaw(buffer, actualPath);
-      return actualPath;
+      int size = sendRaw(buffer, actualPath);
+      return size - headerSize;
     } finally {
       writeLock().unlock();
     }

--- a/src/main/java/org/scion/jpan/ScionService.java
+++ b/src/main/java/org/scion/jpan/ScionService.java
@@ -33,6 +33,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -554,5 +555,20 @@ public class ScionService {
         throw new ScionRuntimeException(e);
       }
     }
+  }
+
+  /**
+   * @param path RequestPath that may need refreshing
+   * @param pathPolicy PathPolicy for selecting a new path when required
+   * @param expiryMargin Expiry margin, i.e. a path is considered "expired" if expiry is less than
+   *     expiryMargin seconds away.
+   * @return `true` if the path was updated, otherwise `false`.
+   */
+  RequestPath refreshPath(RequestPath path, PathPolicy pathPolicy, int expiryMargin) {
+    if (Instant.now().getEpochSecond() + expiryMargin <= path.getExpiration()) {
+      return path;
+    }
+    // expired, get new path
+    return pathPolicy.filter(getPaths(path));
   }
 }

--- a/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
+++ b/src/test/java/org/scion/jpan/api/DatagramChannelApiTest.java
@@ -403,6 +403,17 @@ class DatagramChannelApiTest {
   }
 
   @Test
+  void send_bufferSize() throws IOException {
+    try (ScionDatagramChannel channel = ScionDatagramChannel.open()) {
+      int size0 = channel.send(ByteBuffer.allocate(0), ExamplePacket.PATH);
+      assertEquals(0, size0);
+
+      int size100 = channel.send(ByteBuffer.wrap(new byte[100]), ExamplePacket.PATH);
+      assertEquals(100, size100);
+    }
+  }
+
+  @Test
   void send_bufferTooLarge() {
     RequestPath addr = ExamplePacket.PATH;
     ByteBuffer buffer = ByteBuffer.allocate(65440);
@@ -469,12 +480,15 @@ class DatagramChannelApiTest {
   void send_disconnected_expiredRequestPath() throws IOException {
     // Expected behavior: expired paths should be replaced transparently.
     testExpired(
-        (channel, expiredPath) -> {
+        (channel, expiringPath) -> {
           ByteBuffer sendBuf = ByteBuffer.wrap(PingPongChannelHelper.MSG.getBytes());
           try {
-            RequestPath newPath = (RequestPath) channel.send(sendBuf, expiredPath);
-            assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
+            long oldExpiration = expiringPath.getExpiration();
+            assertTrue(Instant.now().getEpochSecond() > oldExpiration);
+            channel.send(sendBuf, expiringPath);
+            long newExpiration = expiringPath.getExpiration();
+            assertTrue(newExpiration > oldExpiration);
+            assertTrue(Instant.now().getEpochSecond() < newExpiration);
             assertNull(channel.getConnectionPath());
           } catch (IOException e) {
             throw new RuntimeException(e);
@@ -487,13 +501,16 @@ class DatagramChannelApiTest {
   void send_connected_expiredRequestPath() throws IOException {
     // Expected behavior: expired paths should be replaced transparently.
     testExpired(
-        (channel, expiredPath) -> {
+        (channel, expiringPath) -> {
           ByteBuffer sendBuf = ByteBuffer.wrap(PingPongChannelHelper.MSG.getBytes());
           try {
-            RequestPath newPath = (RequestPath) channel.send(sendBuf, expiredPath);
-            assertTrue(newPath.getExpiration() > expiredPath.getExpiration());
-            assertTrue(Instant.now().getEpochSecond() < newPath.getExpiration());
-            assertEquals(newPath, channel.getConnectionPath());
+            long oldExpiration = expiringPath.getExpiration();
+            assertTrue(Instant.now().getEpochSecond() > oldExpiration);
+            channel.send(sendBuf, expiringPath);
+            long newExpiration = expiringPath.getExpiration();
+            assertTrue(newExpiration > oldExpiration);
+            assertTrue(Instant.now().getEpochSecond() < newExpiration);
+            assertEquals(expiringPath, channel.getConnectionPath());
           } catch (IOException e) {
             throw new RuntimeException(e);
           }


### PR DESCRIPTION
`DatagramChannel.send()` should return an `int` instead of a `Path`.