### PR TITLE
Fixed SHIM SCMP error forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [#146](https://github.com/scionproto-contrib/jpan/pull/146)
 
 ### Changed
-- 
+ 
 - Cleaned up test topologies.  [#145](https://github.com/scionproto-contrib/jpan/pull/145)
+
+### Fixed
+
+- SHIM should not crash when receiving unparseable packet (e.g. dstPort = -1).
+  Also, SHIM should parse SCMP error packets correctly.
+  Cleaned up test topologies.  [#148](https://github.com/scionproto-contrib/jpan/pull/148)
 
 ## [0.4.1] - 2024-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix @Disabled tests
 - Create handling for SCMP errors 5 + 6 (interface down, connectivity down). Subclasses?
   fix/113 has packet captures for two of these errors in SCMPTest.java 
+  Adhere to https://docs.scion.org/en/latest/protocols/scmp.html#processing-rules
 - remove ScionAddress?
 - ScionDatagramChannel
   - GatheringByteChannel, ScatteringByteChannel

--- a/src/main/java/org/scion/jpan/Scmp.java
+++ b/src/main/java/org/scion/jpan/Scmp.java
@@ -36,31 +36,33 @@ public class Scmp {
 
   public enum Type implements ParseEnum {
     // SCMP error messages:
-    ERROR_1(1, "Destination Unreachable"),
-    ERROR_2(2, "Packet Too Big"),
-    ERROR_3(3, "(not assigned)"),
-    ERROR_4(4, "Parameter Problem"),
-    ERROR_5(5, "External Interface Down"),
-    ERROR_6(6, "Internal Connectivity Down"),
-    ERROR_100(100, "Private Experimentation"),
-    ERROR_101(101, "Private Experimentation"),
-    ERROR_127(127, "Reserved for expansion of SCMP error messages"),
+    ERROR_1(1, "Destination Unreachable", 8),
+    ERROR_2(2, "Packet Too Big", 8),
+    ERROR_3(3, "(not assigned)", 0),
+    ERROR_4(4, "Parameter Problem", 8),
+    ERROR_5(5, "External Interface Down", 20),
+    ERROR_6(6, "Internal Connectivity Down", 28),
+    ERROR_100(100, "Private Experimentation", 0),
+    ERROR_101(101, "Private Experimentation", 0),
+    ERROR_127(127, "Reserved for expansion of SCMP error messages", 0),
 
     // SCMP informational messages:
-    INFO_128(128, "Echo Request"),
-    INFO_129(129, "Echo Reply"),
-    INFO_130(130, "Traceroute Request"),
-    INFO_131(131, "Traceroute Reply"),
-    INFO_200(200, "Private Experimentation"),
-    INFO_201(201, "Private Experimentation"),
-    INFO_255(255, "Reserved for expansion of SCMP informational messages");
+    INFO_128(128, "Echo Request", 8),
+    INFO_129(129, "Echo Reply", 8),
+    INFO_130(130, "Traceroute Request", 24),
+    INFO_131(131, "Traceroute Reply", 24),
+    INFO_200(200, "Private Experimentation", 0),
+    INFO_201(201, "Private Experimentation", 0),
+    INFO_255(255, "Reserved for expansion of SCMP informational messages", 0);
 
     final int id;
     final String text;
+    final int headerLength;
 
-    Type(int id, String text) {
+    Type(int id, String text, int headerLength) {
       this.id = id;
       this.text = text;
+      this.headerLength = headerLength;
     }
 
     public static Type parse(int id) {
@@ -74,6 +76,10 @@ public class Scmp {
 
     public String getText() {
       return text;
+    }
+
+    public int getHeaderLength() {
+      return headerLength;
     }
 
     @Override

--- a/src/main/java/org/scion/jpan/internal/ScionHeaderParser.java
+++ b/src/main/java/org/scion/jpan/internal/ScionHeaderParser.java
@@ -155,6 +155,12 @@ public class ScionHeaderParser {
     return InternalConstants.HdrTypes.parse(nextHeader);
   }
 
+  /**
+   * Extract the destination socket address without changing the buffer's position.
+   *
+   * @param data The datagram to read from.
+   * @return The destination address or 'null' if no address is available (e.g. SCMP error)
+   */
   public static InetSocketAddress extractDestinationSocketAddress(ByteBuffer data)
       throws UnknownHostException {
     int start = data.position();
@@ -180,6 +186,10 @@ public class ScionHeaderParser {
     data.get(bytesDst);
     InetAddress dstIP = InetAddress.getByAddress(bytesDst);
     int dstPort = extractDstPort(data, start + hdrLenBytes, hdrType);
+    if (dstPort < 0) {
+      // return null, e.g. for truncated SCMP packets
+      return null;
+    }
 
     // rewind to original offset
     data.position(start);
@@ -187,15 +197,15 @@ public class ScionHeaderParser {
   }
 
   private static int extractDstPort(
-      ByteBuffer data, int scmpHdrOffset, InternalConstants.HdrTypes hdrType) {
+      ByteBuffer data, int hdrOffset, InternalConstants.HdrTypes hdrType) {
     int dstPort;
     if (hdrType == InternalConstants.HdrTypes.UDP) {
       // get remote port from UDP overlay
-      data.position(scmpHdrOffset + 2);
+      data.position(hdrOffset + 2);
       dstPort = Short.toUnsignedInt(data.getShort());
     } else if (hdrType == InternalConstants.HdrTypes.SCMP) {
       // get remote port from SCMP header
-      data.position(scmpHdrOffset);
+      data.position(hdrOffset);
       int type = ByteUtil.toUnsigned(data.get());
       Scmp.Type t = Scmp.Type.parse(type);
       if (t == Scmp.Type.INFO_128 || t == Scmp.Type.INFO_130) {
@@ -203,14 +213,14 @@ public class ScionHeaderParser {
         dstPort = Constants.SCMP_PORT;
       } else if (t == Scmp.Type.INFO_129 || t == Scmp.Type.INFO_131) {
         // response -> get port from SCMP identifier
-        data.position(scmpHdrOffset + 4);
+        data.position(hdrOffset + 4);
         dstPort = Short.toUnsignedInt(data.getShort());
       } else {
         int code = ByteUtil.toUnsigned(data.get());
         Scmp.TypeCode tc = Scmp.TypeCode.parse(type, code);
         if (tc.isError()) {
-          // TODO try extracting port from attached packet (may be UDP or SCMP)
-          return -1;
+          // try extracting port from attached packet (may be UDP or SCMP)
+          return extractPortFromPayload(data, hdrOffset + 8);
         }
         throw new UnsupportedOperationException(hdrType.name() + " " + tc.getText());
       }
@@ -218,6 +228,51 @@ public class ScionHeaderParser {
       throw new UnsupportedOperationException();
     }
     return dstPort;
+  }
+
+  private static int extractSrcPort(
+      ByteBuffer data, int hdrOffset, InternalConstants.HdrTypes hdrType) {
+    int dstPort;
+    if (hdrType == InternalConstants.HdrTypes.UDP) {
+      // get remote port from UDP overlay
+      data.position(hdrOffset);
+      dstPort = Short.toUnsignedInt(data.getShort());
+    } else if (hdrType == InternalConstants.HdrTypes.SCMP) {
+      // get remote port from SCMP header
+      data.position(hdrOffset);
+      int type = ByteUtil.toUnsigned(data.get());
+      Scmp.Type t = Scmp.Type.parse(type);
+      if (t == Scmp.Type.INFO_128 || t == Scmp.Type.INFO_130) {
+        // request -> get port from SCMP identifier
+        data.position(hdrOffset + 4);
+        dstPort = Short.toUnsignedInt(data.getShort());
+      } else {
+        // request or error -> port is 30041
+        dstPort = Constants.SCMP_PORT;
+      }
+    } else {
+      throw new UnsupportedOperationException();
+    }
+    return dstPort;
+  }
+
+  private static int extractPortFromPayload(ByteBuffer data, int hdrOffset) {
+    int start = data.position();
+    try {
+      data.position(hdrOffset);
+      int expectedLength = extractPacketLength(data);
+      int hdrLenBytes = extractHeaderLength(data);
+      if (expectedLength != data.remaining()) {
+        // truncated payload
+        return -1;
+      }
+      InternalConstants.HdrTypes hdrType = extractNextHeader(data);
+      return extractSrcPort(data, hdrOffset + hdrLenBytes, hdrType);
+    } catch (Exception e) {
+      return -1;
+    } finally {
+      data.position(start);
+    }
   }
 
   /**

--- a/src/main/java/org/scion/jpan/internal/Shim.java
+++ b/src/main/java/org/scion/jpan/internal/Shim.java
@@ -89,7 +89,7 @@ public class Shim implements AutoCloseable {
   }
 
   private void start() {
-    forwarder = new Thread(this::forwardStarter, "Shim-forwarder");
+    forwarder = new Thread(this::forwardStarter, "Shim-Dispatcher");
     forwarder.setDaemon(true);
     forwarder.start();
     try {
@@ -142,9 +142,13 @@ public class Shim implements AutoCloseable {
     try {
       if (forwardCallback == null || forwardCallback.test(buf)) {
         InetSocketAddress dst = ScionHeaderParser.extractDestinationSocketAddress(buf);
+        if (dst == null) {
+          log.error("SCMP error with truncated UDP header");
+          return;
+        }
         channel.send(buf, dst);
       }
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.info("ERROR while forwarding packet: {}", e.getMessage());
     }
   }

--- a/src/test/java/org/scion/jpan/api/ScmpSenderTest.java
+++ b/src/test/java/org/scion/jpan/api/ScmpSenderTest.java
@@ -343,7 +343,7 @@ public class ScmpSenderTest {
           spi.reversePath();
           ScmpHeader scmpHeader = spi.getScmpHeader();
           scmpHeader.setCode(Scmp.TypeCode.TYPE_1_CODE_0);
-          spi.setPayLoad(payload);
+          scmpHeader.setErrorPayload(payload);
           return payload.length;
         });
     errorChannel.setReceiveCallback(

--- a/src/test/java/org/scion/jpan/demo/inspector/ScionHeader.java
+++ b/src/test/java/org/scion/jpan/demo/inspector/ScionHeader.java
@@ -140,6 +140,11 @@ public class ScionHeader {
     write(data, userPacketLength + 8, pathHeaderLength, pathType, InternalConstants.HdrTypes.UDP);
   }
 
+  public void adjustPayloadLength(ByteBuffer data, int payloadLength) {
+    payLoadLen = payloadLength;
+    data.putShort(6, (short) payloadLength);
+  }
+
   public void write(
       ByteBuffer data,
       int userPacketLength,

--- a/src/test/java/org/scion/jpan/demo/inspector/ScionPacketInspector.java
+++ b/src/test/java/org/scion/jpan/demo/inspector/ScionPacketInspector.java
@@ -175,6 +175,7 @@ public class ScionPacketInspector {
 
   public void writePacketSCMP(ByteBuffer newData) {
     Scmp.Type type = scmpHeader.getType();
+    // TODO use switch!
     EnumSet<Scmp.Type> errors =
         EnumSet.of(
             Scmp.Type.ERROR_1,
@@ -186,7 +187,7 @@ public class ScionPacketInspector {
     if (type == Scmp.Type.INFO_128 || type == Scmp.Type.INFO_129) {
       scionHeader.write(
           newData,
-          scmpHeader.getUserData().length + 8,
+          scmpHeader.getUserData().length + type.getHeaderLength(),
           pathHeaderScion.length(),
           Constants.PathTypes.SCION,
           InternalConstants.HdrTypes.SCMP);
@@ -195,7 +196,7 @@ public class ScionPacketInspector {
     } else if (type == Scmp.Type.INFO_130 || type == Scmp.Type.INFO_131) {
       scionHeader.write(
           newData,
-          24,
+          type.getHeaderLength(),
           pathHeaderScion.length(),
           Constants.PathTypes.SCION,
           InternalConstants.HdrTypes.SCMP);
@@ -204,7 +205,7 @@ public class ScionPacketInspector {
     } else if (errors.contains(type)) {
       scionHeader.write(
           newData,
-          8 + payload.length,
+          type.getHeaderLength() + payload.length,
           pathHeaderScion.length(),
           Constants.PathTypes.SCION,
           InternalConstants.HdrTypes.SCMP);

--- a/src/test/java/org/scion/jpan/demo/inspector/ScionPacketInspector.java
+++ b/src/test/java/org/scion/jpan/demo/inspector/ScionPacketInspector.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.net.*;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.EnumSet;
 import org.scion.jpan.Scmp;
 import org.scion.jpan.internal.InternalConstants;
 
@@ -175,46 +174,23 @@ public class ScionPacketInspector {
 
   public void writePacketSCMP(ByteBuffer newData) {
     Scmp.Type type = scmpHeader.getType();
-    // TODO use switch!
-    EnumSet<Scmp.Type> errors =
-        EnumSet.of(
-            Scmp.Type.ERROR_1,
-            Scmp.Type.ERROR_2,
-            Scmp.Type.ERROR_3,
-            Scmp.Type.ERROR_4,
-            Scmp.Type.ERROR_5,
-            Scmp.Type.ERROR_6);
-    if (type == Scmp.Type.INFO_128 || type == Scmp.Type.INFO_129) {
+    boolean isError = scmpHeader.getCode().isError();
+    if (type == Scmp.Type.INFO_128
+        || type == Scmp.Type.INFO_129
+        || type == Scmp.Type.INFO_130
+        || type == Scmp.Type.INFO_131
+        || isError) {
       scionHeader.write(
           newData,
-          scmpHeader.getUserData().length + type.getHeaderLength(),
+          scmpHeader.getLength(),
           pathHeaderScion.length(),
           Constants.PathTypes.SCION,
           InternalConstants.HdrTypes.SCMP);
-      pathHeaderScion.write(newData);
-      scmpHeader.writeEcho(newData);
-    } else if (type == Scmp.Type.INFO_130 || type == Scmp.Type.INFO_131) {
-      scionHeader.write(
-          newData,
-          type.getHeaderLength(),
-          pathHeaderScion.length(),
-          Constants.PathTypes.SCION,
-          InternalConstants.HdrTypes.SCMP);
-      pathHeaderScion.write(newData);
-      scmpHeader.writeTraceroute(newData);
-    } else if (errors.contains(type)) {
-      scionHeader.write(
-          newData,
-          type.getHeaderLength() + payload.length,
-          pathHeaderScion.length(),
-          Constants.PathTypes.SCION,
-          InternalConstants.HdrTypes.SCMP);
-      pathHeaderScion.write(newData);
-      scmpHeader.writeError(newData);
-      newData.put(payload);
     } else {
       throw new UnsupportedOperationException();
     }
+    pathHeaderScion.write(newData);
+    scmpHeader.write(newData);
   }
 
   public ScmpHeader getScmpHeader() {

--- a/src/test/java/org/scion/jpan/demo/inspector/ScmpHeader.java
+++ b/src/test/java/org/scion/jpan/demo/inspector/ScmpHeader.java
@@ -26,7 +26,7 @@ public class ScmpHeader {
   private int checksum;
   private int short1;
   private int short2;
-  private byte[] echoUserData;
+  private byte[] echoUserData = new byte[0];
   private long traceIsdAs;
   private long traceIfID;
 
@@ -127,6 +127,10 @@ public class ScmpHeader {
   public void setTraceData(long isdAs, int ifID) {
     this.traceIsdAs = isdAs;
     this.traceIfID = ifID;
+  }
+
+  public void setIdentifier(int identifier) {
+    this.short1 = identifier;
   }
 
   public int getSequenceId() {

--- a/src/test/java/org/scion/jpan/demo/inspector/ScmpHeader.java
+++ b/src/test/java/org/scion/jpan/demo/inspector/ScmpHeader.java
@@ -53,9 +53,6 @@ public class ScmpHeader {
       default:
         // SCMP error
     }
-
-    // System.out.println("Found SCMP: " + getType() + " -> " + getCode());
-    // System.out.println("To read:" + data.remaining());
   }
 
   public void writeEcho(ByteBuffer buffer) {
@@ -64,7 +61,7 @@ public class ScmpHeader {
     }
     buffer.put(org.scion.jpan.internal.ByteUtil.toByte(type));
     buffer.put(org.scion.jpan.internal.ByteUtil.toByte(code));
-    buffer.putShort((short) 0); // TODO checksum
+    buffer.putShort((short) 0); // checksum
     buffer.putShort((short) short1); // unsigned identifier
     buffer.putShort((short) short2); // unsigned sequenceNumber
     buffer.put(echoUserData);
@@ -76,7 +73,7 @@ public class ScmpHeader {
     }
     buffer.put(org.scion.jpan.internal.ByteUtil.toByte(type));
     buffer.put(org.scion.jpan.internal.ByteUtil.toByte(code));
-    buffer.putShort((short) 0); // TODO checksum
+    buffer.putShort((short) 0); // checksum
     buffer.putShort((short) short1); // unsigned identifier
     buffer.putShort((short) short2); // unsigned sequenceNumber
 
@@ -97,9 +94,28 @@ public class ScmpHeader {
   public void writeError(ByteBuffer buffer) {
     buffer.put(org.scion.jpan.internal.ByteUtil.toByte(type));
     buffer.put(org.scion.jpan.internal.ByteUtil.toByte(code));
-    buffer.putShort((short) 0); // TODO checksum
-    buffer.putShort((short) short1); // unsigned identifier
-    buffer.putShort((short) short2); // unsigned sequenceNumber
+    buffer.putShort((short) 0); // checksum
+    switch (type) {
+      case 1:
+        buffer.putInt(0); // unused
+        break;
+      case 2:
+      case 4:
+        buffer.putShort((short) 0); // reserved
+        buffer.putShort((short) short2); // 2: MTU; 4: pointer
+        break;
+      case 5:
+        buffer.putLong(0); // ISD/AS
+        buffer.putLong(0); // Interface ID
+        break;
+      case 6:
+        buffer.putLong(0); // ISD/AS
+        buffer.putLong(0); // Ingress Interface ID
+        buffer.putLong(0); // Egress Interface ID
+        break;
+      default:
+        throw new UnsupportedOperationException();
+    }
   }
 
   @Override
@@ -131,9 +147,5 @@ public class ScmpHeader {
 
   public void setIdentifier(int identifier) {
     this.short1 = identifier;
-  }
-
-  public int getSequenceId() {
-    return short2;
   }
 }

--- a/src/test/java/org/scion/jpan/internal/HeaderParseAndReplyTest.java
+++ b/src/test/java/org/scion/jpan/internal/HeaderParseAndReplyTest.java
@@ -105,6 +105,7 @@ class HeaderParseAndReplyTest {
   void extractDstPort_SCMP_129() throws UnknownHostException {
     ByteBuffer data = createScmpResponse(12345, Scmp.TypeCode.TYPE_129, false);
     InetSocketAddress addr = ScionHeaderParser.extractDestinationSocketAddress(data);
+    assertNotNull(addr);
     assertEquals(12345, addr.getPort());
   }
 
@@ -112,6 +113,7 @@ class HeaderParseAndReplyTest {
   void extractDstPort_SCMP_131() throws UnknownHostException {
     ByteBuffer data = createScmpResponse(12345, Scmp.TypeCode.TYPE_131, false);
     InetSocketAddress addr = ScionHeaderParser.extractDestinationSocketAddress(data);
+    assertNotNull(addr);
     assertEquals(12345, addr.getPort());
   }
 
@@ -119,6 +121,7 @@ class HeaderParseAndReplyTest {
   void extractDstPort_SCMP_5() throws UnknownHostException {
     ByteBuffer data = createScmpResponse(12345, Scmp.TypeCode.TYPE_5, false);
     InetSocketAddress addr = ScionHeaderParser.extractDestinationSocketAddress(data);
+    assertNotNull(addr);
     assertEquals(44444, addr.getPort());
   }
 

--- a/src/test/java/org/scion/jpan/internal/HeaderParseAndReplyTest.java
+++ b/src/test/java/org/scion/jpan/internal/HeaderParseAndReplyTest.java
@@ -194,49 +194,4 @@ class HeaderParseAndReplyTest {
     data.flip();
     return data;
   }
-
-  private byte[] createScmpPacket(int dstPort, Scmp.TypeCode type) {
-    ScionPacketInspector spi = ScionPacketInspector.createEmpty();
-    ScionHeader scionHeader = spi.getScionHeader();
-    scionHeader.setSrcHostAddress(new byte[] {127, 0, 0, 1});
-    scionHeader.setDstHostAddress(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
-    scionHeader.setSrcIA(ScionUtil.parseIA("1-ff00:0:110"));
-    scionHeader.setDstIA(ScionUtil.parseIA("1-ff00:0:112"));
-
-    byte[] path = ExamplePacket.PATH_RAW_TINY_110_112;
-    PathHeaderScion pathHeader = spi.getPathHeaderScion();
-    pathHeader.read(ByteBuffer.wrap(path)); // Initialize path
-
-    ScmpHeader scmpHeader = spi.getScmpHeader();
-    scmpHeader.setCode(type);
-    switch (type) {
-      case TYPE_128:
-      case TYPE_129:
-      case TYPE_130:
-      case TYPE_131:
-        scmpHeader.setIdentifier(dstPort);
-        break;
-      case TYPE_1_CODE_0:
-        break;
-      case TYPE_2:
-        break;
-      case TYPE_3:
-        break;
-      case TYPE_4_CODE_0:
-        break;
-      case TYPE_5:
-        break;
-      case TYPE_6:
-        break;
-      default:
-        throw new UnsupportedOperationException();
-    }
-
-    ByteBuffer data = ByteBuffer.allocate(1000);
-    spi.writePacketSCMP(data);
-    data.flip();
-    byte[] result = new byte[data.remaining()];
-    data.get(result);
-    return result;
-  }
 }

--- a/src/test/java/org/scion/jpan/internal/HeaderParseAndReplyTest.java
+++ b/src/test/java/org/scion/jpan/internal/HeaderParseAndReplyTest.java
@@ -18,12 +18,16 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.scion.jpan.Path;
-import org.scion.jpan.ScionService;
-import org.scion.jpan.ScionUtil;
+import org.scion.jpan.*;
+import org.scion.jpan.demo.inspector.PathHeaderScion;
+import org.scion.jpan.demo.inspector.ScionHeader;
+import org.scion.jpan.demo.inspector.ScionPacketInspector;
+import org.scion.jpan.demo.inspector.ScmpHeader;
 import org.scion.jpan.testutil.ExamplePacket;
 
 class HeaderParseAndReplyTest {
@@ -68,5 +72,91 @@ class HeaderParseAndReplyTest {
     for (int i = 0; i < path.length; i++) {
       assertEquals(reversedBytes[i + 48], path[i], "At position:" + i);
     }
+  }
+
+  // 0/300
+  byte[] baError5 = {
+    0, 0, 0, 1, -54, 32, 0, -84, 1, 0, 0, 0, 0, 64, 0, 2, 0, 0, 0, 9, 0, 64, 0, 0, 0, 0, 26, 74,
+    -127, -124, -26, 73, 10, -60, 8, 67, 69, 0, 64, -128, 1, 0, -118, 102, 103, 88, 25, 99, 1, 0,
+    -71, -86, 103, 88, 54, -103, 0, 63, 0, 0, 0, 20, -80, 106, 76, -30, -66, -86, 0, 63, 0, 12, 0,
+    16, 28, 58, -71, 95, -105, -75, 0, 63, 0, 27, 0, 10, 53, 71, 34, 63, -87, -53, 0, 63, 0, 16, 0,
+    0, 63, -75, -65, 36, 116, 26, 0, 63, 0, 0, 0, 5, -78, -9, 46, -124, -74, -126, 0, 63, 0, 1, 0,
+    0, -118, 38, -58, 52, 32, -31, 5, 0, 16, 83, 0, 64, 0, 0, 0, 0, 26, 74, 0, 0, 0, 0, 0, 0, 0, 27,
+    0, 0, 0, 1, -54, 32, 0, 24, 1, 0, 0, 0, 0, 64, 0, 0, 0, 0, 12, -25, 0, 64, 0, 2, 0, 0, 0, 9, 1,
+    2, 3, 4, -127, -124, -26, 73, 67, 0, 33, 0, 0, 0, 11, 93, 103, 88, 54, -103, 0, 0, -65, 33, 103,
+    88, 25, 99, 0, 63, 0, 1, 0, 0, -118, 38, -58, 52, 32, -31, 0, 63, 0, 0, 0, 5, -78, -9, 46, -124,
+    -74, -126, 0, 63, 0, 16, 0, 0, 63, -75, -65, 36, 116, 26, 2, 63, 0, 27, 0, 10, 53, 71, 34, 63,
+    -87, -53, 0, 63, 0, 12, 0, 16, 28, 58, -71, 95, -105, -75, 0, 63, 0, 0, 0, 20, -80, 106, 76,
+    -30, -66, -86, -126, 0, 0, 0, 121, 24, 1, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  };
+
+  @Test
+  void extractDestination_SCMP_error_5() {
+    // Example with actual error from the PRODUCTION network
+    ByteBuffer bb = ByteBuffer.wrap(baError5);
+    try {
+      assertNull(ScionHeaderParser.extractDestinationSocketAddress(bb));
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void extractDstPort_SCMP_129() throws UnknownHostException {
+    ByteBuffer data = createScmpResponse(12345, Scmp.TypeCode.TYPE_129, false);
+    InetSocketAddress addr = ScionHeaderParser.extractDestinationSocketAddress(data);
+    assertEquals(12345, addr.getPort());
+  }
+
+  @Test
+  void extractDstPort_SCMP_131() throws UnknownHostException {
+    ByteBuffer data = createScmpResponse(12345, Scmp.TypeCode.TYPE_131, false);
+    InetSocketAddress addr = ScionHeaderParser.extractDestinationSocketAddress(data);
+    assertEquals(12345, addr.getPort());
+  }
+
+  @Test
+  void extractDstPort_SCMP_5() throws UnknownHostException {
+    ByteBuffer data = createScmpResponse(12345, Scmp.TypeCode.TYPE_5, false);
+    InetSocketAddress addr = ScionHeaderParser.extractDestinationSocketAddress(data);
+    assertEquals(44444, addr.getPort());
+  }
+
+  @Test
+  void extractDstPort_SCMP_5_truncated() throws UnknownHostException {
+    ByteBuffer data = createScmpResponse(12345, Scmp.TypeCode.TYPE_5, true);
+    assertNull(ScionHeaderParser.extractDestinationSocketAddress(data));
+  }
+
+  private ByteBuffer createScmpResponse(int dstPort, Scmp.TypeCode type, boolean truncatePayload) {
+    ScionPacketInspector spi = ScionPacketInspector.createEmpty();
+    ScionHeader scionHeader = spi.getScionHeader();
+    scionHeader.setSrcHostAddress(new byte[] {127, 0, 0, 1});
+    scionHeader.setDstHostAddress(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+    scionHeader.setSrcIA(ScionUtil.parseIA("1-ff00:0:110"));
+    scionHeader.setDstIA(ScionUtil.parseIA("1-ff00:0:112"));
+
+    byte[] path = ExamplePacket.PATH_RAW_TINY_110_112;
+    PathHeaderScion pathHeader = spi.getPathHeaderScion();
+    pathHeader.read(ByteBuffer.wrap(path)); // Initialize path
+
+    ScmpHeader scmpHeader = spi.getScmpHeader();
+    scmpHeader.setCode(type);
+    if (type == Scmp.TypeCode.TYPE_131 || type == Scmp.TypeCode.TYPE_129) {
+      scmpHeader.setIdentifier(dstPort);
+    } else if (type == Scmp.TypeCode.TYPE_5) {
+      byte[] payload = ExamplePacket.PACKET_BYTES_SERVER_E2E_PING;
+      if (truncatePayload) {
+        payload = Arrays.copyOf(payload, payload.length - 1);
+      }
+      spi.setPayLoad(payload);
+    } else {
+      throw new UnsupportedOperationException();
+    }
+
+    ByteBuffer data = ByteBuffer.allocate(1000);
+    spi.writePacketSCMP(data);
+    data.flip();
+    return data;
   }
 }

--- a/src/test/java/org/scion/jpan/internal/HeaderParseAndReplyTest.java
+++ b/src/test/java/org/scion/jpan/internal/HeaderParseAndReplyTest.java
@@ -181,9 +181,9 @@ class HeaderParseAndReplyTest {
       scmpHeader.setIdentifier(dstPort);
     } else if (type == Scmp.TypeCode.TYPE_5) {
       if (truncatePayload) {
-        spi.setPayLoad(Arrays.copyOf(payload, payload.length - 1));
+        scmpHeader.setErrorPayload(Arrays.copyOf(payload, payload.length - 1));
       } else {
-        spi.setPayLoad(payload);
+        scmpHeader.setErrorPayload(payload);
       }
     } else {
       throw new UnsupportedOperationException();

--- a/src/test/java/org/scion/jpan/internal/ShimTest.java
+++ b/src/test/java/org/scion/jpan/internal/ShimTest.java
@@ -104,19 +104,19 @@ class ShimTest {
     assertTrue(Shim.isInstalled());
 
     // test that SCMP echo requests are answered
-    testScmpEchoReflect();
-    testScmpEchoReflect();
-
-    testScmpEchoResponse();
-
-    testScmpResponse(Scmp.TypeCode.TYPE_129);
-    testScmpResponse(Scmp.TypeCode.TYPE_129);
-    // test traceroute response
-    testScmpResponse(Scmp.TypeCode.TYPE_131);
-    testScmpResponse(Scmp.TypeCode.TYPE_131);
-    // test SCMP error with truncated payload
-    testScmpResponse(Scmp.TypeCode.TYPE_5, true);
-    testScmpResponse(Scmp.TypeCode.TYPE_5, true);
+    //    testScmpEchoReflect();
+    //    testScmpEchoReflect();
+    //
+    //    testScmpEchoResponse();
+    //
+    //    testScmpResponse(Scmp.TypeCode.TYPE_129);
+    //    testScmpResponse(Scmp.TypeCode.TYPE_129);
+    //    // test traceroute response
+    //    testScmpResponse(Scmp.TypeCode.TYPE_131);
+    //    testScmpResponse(Scmp.TypeCode.TYPE_131);
+    //    // test SCMP error with truncated payload
+    //    testScmpResponse(Scmp.TypeCode.TYPE_5, true);
+    //    testScmpResponse(Scmp.TypeCode.TYPE_5, true);
     // test SCMP error
     testScmpResponse(Scmp.TypeCode.TYPE_5);
     testScmpResponse(Scmp.TypeCode.TYPE_5);
@@ -219,7 +219,7 @@ class ShimTest {
         if (truncatePayload) {
           payload = Arrays.copyOf(payload, payload.length - 1);
         }
-        spi.setPayLoad(payload);
+        scmpHeader.setErrorPayload(payload);
       } else {
         throw new UnsupportedOperationException();
       }

--- a/src/test/java/org/scion/jpan/internal/ShimTest.java
+++ b/src/test/java/org/scion/jpan/internal/ShimTest.java
@@ -20,11 +20,20 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.*;
 import org.scion.jpan.*;
+import org.scion.jpan.Constants;
+import org.scion.jpan.demo.inspector.PathHeaderScion;
+import org.scion.jpan.demo.inspector.ScionHeader;
+import org.scion.jpan.demo.inspector.ScionPacketInspector;
+import org.scion.jpan.demo.inspector.ScmpHeader;
+import org.scion.jpan.testutil.ExamplePacket;
+import org.scion.jpan.testutil.ManagedThread;
 import org.scion.jpan.testutil.MockNetwork;
 import org.scion.jpan.testutil.MockNetwork2;
 import org.scion.jpan.testutil.MockScmpHandler;
@@ -98,6 +107,20 @@ class ShimTest {
     testScmpEchoReflect();
     testScmpEchoReflect();
 
+    testScmpEchoResponse();
+
+    testScmpResponse(Scmp.TypeCode.TYPE_129);
+    testScmpResponse(Scmp.TypeCode.TYPE_129);
+    // test traceroute response
+    testScmpResponse(Scmp.TypeCode.TYPE_131);
+    testScmpResponse(Scmp.TypeCode.TYPE_131);
+    // test SCMP error with truncated payload
+    testScmpResponse(Scmp.TypeCode.TYPE_5, true);
+    testScmpResponse(Scmp.TypeCode.TYPE_5, true);
+    // test SCMP error
+    testScmpResponse(Scmp.TypeCode.TYPE_5);
+    testScmpResponse(Scmp.TypeCode.TYPE_5);
+
     // check double install doesn't fail
     Shim.install(null);
     assertTrue(Shim.isInstalled());
@@ -112,6 +135,7 @@ class ShimTest {
   }
 
   private void testScmpEchoReflect() throws IOException {
+    // Test that the SHIM answers SCMP requests
     try (ScmpSender sender = Scmp.newSenderBuilder().build()) {
       Path path = createDummyPath(Constants.SCMP_PORT);
       Scmp.EchoMessage msg = sender.sendEchoRequest(path, ByteBuffer.allocate(0));
@@ -119,10 +143,106 @@ class ShimTest {
     }
   }
 
+  private void testScmpEchoResponse() throws IOException {
+    // Test that an SCMP echo response ca n be forwarded by the SHIM
+    ManagedThread responder = ManagedThread.newBuilder().build();
+    AtomicInteger counter = new AtomicInteger();
+    int port = 31212; // Port from non-dispatched port range
+    try (ScmpSender sender = Scmp.newSenderBuilder().build();
+        ScmpResponder scmpResponder = Scmp.newResponderBuilder().setLocalPort(port).build()) {
+      scmpResponder.setScmpEchoListener(echoMessage -> counter.incrementAndGet() > 0);
+      responder.submit(
+          news -> {
+            news.reportStarted();
+            scmpResponder.start();
+          });
+
+      Path path = createDummyPath(port);
+      Scmp.EchoMessage msg = sender.sendEchoRequest(path, ByteBuffer.allocate(0));
+      assertFalse(msg.isTimedOut());
+      assertEquals(1, counter.get());
+    } finally {
+      responder.join(10);
+    }
+  }
+
+  private void testScmpResponse(Scmp.TypeCode scmpTypeCode) {
+    testScmpResponse(scmpTypeCode, false);
+  }
+
+  private void testScmpResponse(Scmp.TypeCode scmpTypeCode, boolean expectError) {
+    // This should happen e.g. for SCMP errors with truncated payload where the SHIM cannot
+    // extract the original port.
+    ManagedThread receiver = ManagedThread.newBuilder().expectException(expectError).build();
+    AtomicInteger counter = new AtomicInteger();
+    int port = 44444; // Use a port from the dispatcher mapped range
+    InetSocketAddress senderAddr = IPHelper.toInetSocketAddress("[::1]:" + port);
+    try {
+      receiver.submit(
+          news -> {
+            try (DatagramChannel scmpReceiver = DatagramChannel.open()) {
+              scmpReceiver.bind(senderAddr);
+              news.reportStarted();
+              ByteBuffer buf = ByteBuffer.allocate(1000);
+              scmpReceiver.receive(buf);
+              counter.incrementAndGet();
+            }
+          });
+
+      sendScmpResponse(port, scmpTypeCode, expectError);
+    } finally {
+      receiver.join(10);
+    }
+    assertEquals(expectError ? 0 : 1, counter.get());
+  }
+
+  private void sendScmpResponse(int dstPort, Scmp.TypeCode type, boolean truncatePayload) {
+    try (DatagramChannel sender = DatagramChannel.open()) {
+      ScionPacketInspector spi = ScionPacketInspector.createEmpty();
+      ScionHeader scionHeader = spi.getScionHeader();
+      scionHeader.setSrcHostAddress(new byte[] {127, 0, 0, 1});
+      scionHeader.setDstHostAddress(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+      scionHeader.setSrcIA(ScionUtil.parseIA("1-ff00:0:110"));
+      scionHeader.setDstIA(ScionUtil.parseIA("1-ff00:0:112"));
+
+      byte[] path = ExamplePacket.PATH_RAW_TINY_110_112;
+      PathHeaderScion pathHeader = spi.getPathHeaderScion();
+      pathHeader.read(ByteBuffer.wrap(path)); // Initialize path
+
+      ScmpHeader scmpHeader = spi.getScmpHeader();
+      scmpHeader.setCode(type);
+      if (type == Scmp.TypeCode.TYPE_131 || type == Scmp.TypeCode.TYPE_129) {
+        scmpHeader.setIdentifier(dstPort);
+      } else if (type == Scmp.TypeCode.TYPE_5) {
+        byte[] payload = ExamplePacket.PACKET_BYTES_SERVER_E2E_PING;
+        if (truncatePayload) {
+          payload = Arrays.copyOf(payload, payload.length - 1);
+        }
+        spi.setPayLoad(payload);
+      } else {
+        throw new UnsupportedOperationException();
+      }
+
+      ByteBuffer data = ByteBuffer.allocate(1000);
+      spi.writePacketSCMP(data);
+      data.flip();
+
+      InetSocketAddress shim =
+          new InetSocketAddress(InetAddress.getLoopbackAddress(), Constants.SCMP_PORT);
+      sender.send(data, shim);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private Path createDummyPath(int serverPort) {
+    InetSocketAddress firstHop = new InetSocketAddress(InetAddress.getLoopbackAddress(), 12321);
+    return createDummyPath(serverPort, firstHop);
+  }
+
+  private Path createDummyPath(int serverPort, InetSocketAddress firstHop) {
     long localIA = ScionUtil.parseIA("1-ff00:0:110");
     InetAddress dstAddr = InetAddress.getLoopbackAddress();
-    InetSocketAddress firstHop = new InetSocketAddress(InetAddress.getLoopbackAddress(), 12321);
     return PackageVisibilityHelper.createDummyPath(
         localIA, dstAddr, serverPort, new byte[0], firstHop);
   }

--- a/src/test/java/org/scion/jpan/internal/ShimTest.java
+++ b/src/test/java/org/scion/jpan/internal/ShimTest.java
@@ -190,8 +190,9 @@ class ShimTest {
           });
 
       sendScmpResponse(port, scmpTypeCode, expectError);
-    } finally {
       receiver.join(10);
+    } finally {
+      receiver.stopNow();
     }
     assertEquals(expectError ? 0 : 1, counter.get());
   }

--- a/src/test/java/org/scion/jpan/testutil/MockBorderRouter.java
+++ b/src/test/java/org/scion/jpan/testutil/MockBorderRouter.java
@@ -148,7 +148,7 @@ public class MockBorderRouter implements Runnable {
 
     // Forward packet to DST unless it is meant for us (us=bind1).
     InetSocketAddress dstIP = ScionHeaderParser.extractDestinationSocketAddress(buffer);
-    if (type0 == Scmp.Type.INFO_128 && dstIP.getAddress() != bind1.getAddress()) {
+    if (dstIP != null && type0 == Scmp.Type.INFO_128 && dstIP.getAddress() != bind1.getAddress()) {
       buffer.rewind();
       forwardPacket(buffer, srcAddress, outgoing);
       return;

--- a/src/test/java/org/scion/jpan/testutil/MockBorderRouter.java
+++ b/src/test/java/org/scion/jpan/testutil/MockBorderRouter.java
@@ -176,7 +176,7 @@ public class MockBorderRouter implements Runnable {
     spi.reversePath();
     ScmpHeader scmpHeader = spi.getScmpHeader();
     scmpHeader.setCode(type);
-    spi.setPayLoad(payload);
+    scmpHeader.setErrorPayload(payload);
     ByteBuffer out = ByteBuffer.allocate(1232); // 1232 limit, see spec
     spi.writePacketSCMP(out);
     out.flip();

--- a/src/test/java/org/scion/jpan/testutil/MockNetwork2.java
+++ b/src/test/java/org/scion/jpan/testutil/MockNetwork2.java
@@ -62,6 +62,7 @@ public class MockNetwork2 implements AutoCloseable {
     controlServer.getAndResetCallCount();
   }
 
+  @Override
   public void close() {
     controlServer.close();
     topoServer.close();


### PR DESCRIPTION
The dispatcher SHIM fails to forward SCMP errors and instead crashes.
Expected:
- The SHIM should never crash
- SCMP errors should be forwarded if possible, to the source port of the error-causing packet (unless the packet is truncated)
