### PR TITLE
/etc/hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ For example: Path.getFirstHopAddress(), DatagramChannel.setPathPolicy()
   Cleaned up test topologies.  [#148](https://github.com/scionproto-contrib/jpan/pull/148)
 - Fixed disabled SHIM tests and general test cleanup.  
   [#149](https://github.com/scionproto-contrib/jpan/pull/149)
+- Fixed parsing of /etc/hosts [#151](https://github.com/scionproto-contrib/jpan/pull/151)
 
 ## [0.4.1] - 2024-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ For example: Path.getFirstHopAddress(), DatagramChannel.setPathPolicy()
   Cleaned up test topologies.  [#148](https://github.com/scionproto-contrib/jpan/pull/148)
 - Fixed disabled SHIM tests and general test cleanup.  
   [#149](https://github.com/scionproto-contrib/jpan/pull/149)
-- Fixed parsing of /etc/hosts [#151](https://github.com/scionproto-contrib/jpan/pull/151)
+- Fixed parsing of /etc/hosts [#150](https://github.com/scionproto-contrib/jpan/pull/150)
 
 ## [0.4.1] - 2024-11-22
 

--- a/src/main/java/org/scion/jpan/internal/HostsFileParser.java
+++ b/src/main/java/org/scion/jpan/internal/HostsFileParser.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 public class HostsFileParser {
 
   private static final Logger LOG = LoggerFactory.getLogger(HostsFileParser.class);
-  private static final String PATH_LINUX = "/etc/scion/hosts";
+  private static final String PATH_LINUX = "/etc/scion/hosts;/etc/hosts";
   private final String propHostsFiles =
       ScionUtil.getPropertyOrEnv(Constants.PROPERTY_HOSTS_FILES, Constants.ENV_HOSTS_FILES);
 


### PR DESCRIPTION
Add `/etc/hosts` to the default parsed host files (next to `/etc/scion/hosts`).