### PR TITLE
grpc-netty-shaded jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ For example: `Path.getFirstHopAddress()`, `DatagramChannel.setPathPolicy()`
   [#157](https://github.com/scionproto-contrib/jpan/pull/157)
 - Fixed troubleshooting documentation for slf4j
   [#161](https://github.com/scionproto-contrib/jpan/pull/161)
+- Fixed Android problems with grpc-netty-shaded jar.
+  [#165](https://github.com/scionproto-contrib/jpan/pull/165)
 
 ## [0.4.1] - 2024-11-22
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.scion</groupId>
@@ -117,7 +119,10 @@
 
         <dependency>
             <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty-shaded</artifactId>
+            <!-- TODO We are not using the shaded version because it causes problem with Android.
+             However, we have to look at this again because shading helps avoiding dependency
+              conflicts if the application is using netty somewhere. -->
+            <artifactId>grpc-netty</artifactId>
             <version>${scion.io-grpc.version}</version>
         </dependency>
 
@@ -324,7 +329,9 @@
                         <Export-Package>
                             org.scion.jpan.*
                         </Export-Package>
-                        <_removeheaders>Bnd-*, Tool, Require-Capability, Include-Resource, Private-Package</_removeheaders>
+                        <_removeheaders>Bnd-*, Tool, Require-Capability, Include-Resource,
+                            Private-Package
+                        </_removeheaders>
                         <Include-Resource>
                             {maven-resources},
                             META-INF/LICENSE=LICENSE
@@ -342,7 +349,8 @@
                             <goal>antlr4</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.basedir}/target/generated-sources</outputDirectory>
+                            <outputDirectory>${project.basedir}/target/generated-sources
+                            </outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -119,10 +119,10 @@
 
         <dependency>
             <groupId>io.grpc</groupId>
-            <!-- TODO We are not using the shaded version because it causes problem with Android.
-             However, we have to look at this again because shading helps avoiding dependency
-              conflicts if the application is using netty somewhere. -->
-            <artifactId>grpc-netty</artifactId>
+            <!-- TODO We are not using the (netty) shaded version because it causes problem with
+            Android. However, we have to look at this again because shading helps avoiding
+            dependency conflicts if the application is using netty/okhttp elsewhere. -->
+            <artifactId>grpc-okhttp</artifactId>
             <version>${scion.io-grpc.version}</version>
         </dependency>
 


### PR DESCRIPTION
Remove usage of `grpc-netty-shaded` because it causes problems with Android execution.
`grpc-netty` actually worked with android, but `grpc-okhttp` seems to be the better option because it promises compatibility with Android older version and check compatibility with current versions.