### PR TITLE
Fixed error in case of no CORE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ TODO
   [#177](https://github.com/scionproto-contrib/jpan/pull/177)
 - Cleanup unit tests for segments.
   [#178](https://github.com/scionproto-contrib/jpan/pull/178)
+- Report path not found if no CORE segments are available.
+  [#185](https://github.com/scionproto-contrib/jpan/pull/185)
   
 ## [0.5.3] - 2025-04-14
 

--- a/src/main/java/org/scion/jpan/internal/Segments.java
+++ b/src/main/java/org/scion/jpan/internal/Segments.java
@@ -127,6 +127,10 @@ public class Segments {
     // Even if the DST is reachable without a CORE segment (e.g. it is directly a reachable leaf)
     // we still should look at core segments because they may offer additional paths.
     List<PathSegment> segmentsCore = getSegments(service, srcWildcard, dstWildcard);
+    if (ScionUtil.extractIsd(srcIsdAs) != ScionUtil.extractIsd(dstIsdAs)
+        && segmentsCore.isEmpty()) {
+      return Collections.emptyList();
+    }
     if (localAS.isCoreAs()) {
       // SRC is core, we can disregard all CORE segments that don't end with SRC
       segmentsCore = filterForEndIsdAs(segmentsCore, srcIsdAs);


### PR DESCRIPTION
If no CORE segments are available, we should abort early instead of requesting DOWN segments.