### PR TITLE
SCMP port handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,19 +180,8 @@ TODO
   [#232](https://github.com/scionproto-contrib/jpan/pull/232)
 - SCMP message port parsing is broken.
   [#233](https://github.com/scionproto-contrib/jpan/issues/233)
-TODO
-- ScmpParser.buildScmpPing is directly converting int to short
-  Test whether this works with sender-port >= 32768
 - Weird NPE in full PathProbviderWithRefreshTest.multiISD()
   [#235](https://github.com/scionproto-contrib/jpan/issues/235)
-  java.lang.NullPointerException: Cannot invoke "java.net.InetSocketAddress.getAddress()" because "dstScionAddress" is null
-  at org.scion.jpan.ScionService.getPaths(ScionService.java:268)
-  at org.scion.jpan.internal.PathProviderWithRefresh.refreshPaths(PathProviderWithRefresh.java:187)
-  at org.scion.jpan.internal.PathProviderWithRefresh$1.run(PathProviderWithRefresh.java:168)
-  at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
-  at java.base/java.util.concurrent.FutureTask.runAndReset$$$capture(FutureTask.java:358)
-  at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java)
-
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,11 @@ TODO
 - Ensure that SHIM and ScmpResponder do not respond to broadcast-source addresses.
   [#230](https://github.com/scionproto-contrib/jpan/pull/230)
   [#232](https://github.com/scionproto-contrib/jpan/pull/232)
+- SCMP message port parsing is broken.
+  [#233](https://github.com/scionproto-contrib/jpan/issues/233)
+TODO
+- ScmpParser.buildScmpPing is directly converting int to short
+  Test whether this works with sender-port >= 32768
 - Weird NPE in full PathProbviderWithRefreshTest.multiISD()
   [#235](https://github.com/scionproto-contrib/jpan/issues/235)
   java.lang.NullPointerException: Cannot invoke "java.net.InetSocketAddress.getAddress()" because "dstScionAddress" is null

--- a/src/main/java/org/scion/jpan/ScmpResponder.java
+++ b/src/main/java/org/scion/jpan/ScmpResponder.java
@@ -194,7 +194,7 @@ public class ScmpResponder implements AutoCloseable {
             ByteUtil.MutInt srcPort = new ByteUtil.MutInt(-1);
             buildHeader(buffer, msg.getPath(), len, HeaderConstants.HdrTypes.SCMP.code(), srcPort);
             ScmpParser.buildScmpPing(
-                buffer, Scmp.Type.INFO_129, srcPort.get(), msg.getSequenceNumber(), msg.getData());
+                buffer, Scmp.Type.INFO_129, msg.getIdentifier(), msg.getSequenceNumber(), msg.getData());
             buffer.flip();
             msg.setSizeSent(buffer.remaining());
             sendRaw(buffer, path);

--- a/src/main/java/org/scion/jpan/ScmpResponder.java
+++ b/src/main/java/org/scion/jpan/ScmpResponder.java
@@ -194,7 +194,11 @@ public class ScmpResponder implements AutoCloseable {
             ByteUtil.MutInt srcPort = new ByteUtil.MutInt(-1);
             buildHeader(buffer, msg.getPath(), len, HeaderConstants.HdrTypes.SCMP.code(), srcPort);
             ScmpParser.buildScmpPing(
-                buffer, Scmp.Type.INFO_129, msg.getIdentifier(), msg.getSequenceNumber(), msg.getData());
+                buffer,
+                Scmp.Type.INFO_129,
+                msg.getIdentifier(),
+                msg.getSequenceNumber(),
+                msg.getData());
             buffer.flip();
             msg.setSizeSent(buffer.remaining());
             sendRaw(buffer, path);

--- a/src/main/java/org/scion/jpan/internal/Shim.java
+++ b/src/main/java/org/scion/jpan/internal/Shim.java
@@ -37,6 +37,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The SHIM responds to SCMP echo request. All other packets will be forwarded to the destination
  * address encoded in the SCION header. If parsing of the SCION header fails, the packet is dropped.
+ *
+ * <p>Implementation note: the SHIM doesn't run it's own thread. Instead is runs an ScmpResponder
+ * and register itself as a callback. The SHIM will never have to deal with SCMP packets.
  */
 public class Shim implements AutoCloseable {
   private static final Logger log = LoggerFactory.getLogger(Shim.class);

--- a/src/main/java/org/scion/jpan/internal/header/ScionHeaderParser.java
+++ b/src/main/java/org/scion/jpan/internal/header/ScionHeaderParser.java
@@ -133,8 +133,13 @@ public class ScionHeaderParser {
     } else if (hdrType == HeaderConstants.HdrTypes.SCMP) {
       switch (Scmp.Type.parse(Byte.toUnsignedInt(data.get(hdrLenBytes)))) {
         case INFO_128:
-        case INFO_129:
         case INFO_130:
+          data.position(hdrLenBytes + 4);
+          // ports will be swapped further down
+          dstPort = Constants.SCMP_PORT;
+          srcPort = Short.toUnsignedInt(data.getShort());
+          break;
+        case INFO_129:
         case INFO_131:
           data.position(hdrLenBytes + 4);
           // ports will be swapped further down
@@ -250,11 +255,11 @@ public class ScionHeaderParser {
 
   private static int extractSrcPort(
       ByteBuffer data, int hdrOffset, HeaderConstants.HdrTypes hdrType) {
-    int dstPort;
+    int srcPort;
     if (hdrType == HeaderConstants.HdrTypes.UDP) {
       // get remote port from UDP overlay
       data.position(hdrOffset);
-      dstPort = Short.toUnsignedInt(data.getShort());
+      srcPort = Short.toUnsignedInt(data.getShort());
     } else if (hdrType == HeaderConstants.HdrTypes.SCMP) {
       // get remote port from SCMP header
       data.position(hdrOffset);
@@ -263,15 +268,15 @@ public class ScionHeaderParser {
       if (t == Scmp.Type.INFO_128 || t == Scmp.Type.INFO_130) {
         // request -> get port from SCMP identifier
         data.position(hdrOffset + 4);
-        dstPort = Short.toUnsignedInt(data.getShort());
+        srcPort = Short.toUnsignedInt(data.getShort());
       } else {
-        // request or error -> port is 30041
-        dstPort = Constants.SCMP_PORT;
+        // response or error -> port is 30041
+        srcPort = Constants.SCMP_PORT;
       }
     } else {
       throw new UnsupportedOperationException();
     }
-    return dstPort;
+    return srcPort;
   }
 
   private static int extractPortFromPayload(ByteBuffer fullData, int hdrOffset) {

--- a/src/main/java/org/scion/jpan/internal/header/ScionHeaderParser.java
+++ b/src/main/java/org/scion/jpan/internal/header/ScionHeaderParser.java
@@ -124,36 +124,8 @@ public class ScionHeaderParser {
 
     // get remote port from UDP or SCMP payload
     data.position(hdrLenBytes);
-    int srcPort;
-    int dstPort;
-    if (hdrType == HeaderConstants.HdrTypes.UDP) {
-      // get remote port from UDP overlay
-      srcPort = Short.toUnsignedInt(data.getShort());
-      dstPort = Short.toUnsignedInt(data.getShort());
-    } else if (hdrType == HeaderConstants.HdrTypes.SCMP) {
-      switch (Scmp.Type.parse(Byte.toUnsignedInt(data.get(hdrLenBytes)))) {
-        case INFO_128:
-        case INFO_130:
-          data.position(hdrLenBytes + 4);
-          // ports will be swapped further down
-          dstPort = Constants.SCMP_PORT;
-          srcPort = Short.toUnsignedInt(data.getShort());
-          break;
-        case INFO_129:
-        case INFO_131:
-          data.position(hdrLenBytes + 4);
-          // ports will be swapped further down
-          dstPort = Short.toUnsignedInt(data.getShort());
-          srcPort = Constants.SCMP_PORT;
-          break;
-        default:
-          // All errors and 200, 201, 255
-          dstPort = 0;
-          srcPort = 0;
-      }
-    } else {
-      throw new UnsupportedOperationException();
-    }
+    int srcPort = extractSrcPort(data, hdrLenBytes, hdrType);
+    int dstPort = extractDstPort(data, hdrLenBytes, hdrType);
 
     // rewind to original offset
     data.position(start);
@@ -220,63 +192,67 @@ public class ScionHeaderParser {
 
   private static int extractDstPort(
       ByteBuffer data, int hdrOffset, HeaderConstants.HdrTypes hdrType) {
-    int dstPort;
     if (hdrType == HeaderConstants.HdrTypes.UDP) {
       // get remote port from UDP overlay
       data.position(hdrOffset + 2);
-      dstPort = Short.toUnsignedInt(data.getShort());
+      return Short.toUnsignedInt(data.getShort());
     } else if (hdrType == HeaderConstants.HdrTypes.SCMP) {
       // get remote port from SCMP header
       data.position(hdrOffset);
       int type = ByteUtil.toUnsigned(data.get());
-      Scmp.Type t = Scmp.Type.parse(type);
-      if (t == Scmp.Type.INFO_128 || t == Scmp.Type.INFO_130) {
-        // request -> port is 30041
-        dstPort = Constants.SCMP_PORT;
-      } else if (t == Scmp.Type.INFO_129 || t == Scmp.Type.INFO_131) {
-        // response -> get port from SCMP identifier
-        data.position(hdrOffset + 4);
-        dstPort = Short.toUnsignedInt(data.getShort());
-      } else {
-        int code = ByteUtil.toUnsigned(data.get());
-        Scmp.TypeCode tc = Scmp.TypeCode.parse(type, code);
-        if (tc.isError()) {
-          // try extracting port from attached packet (may be UDP or SCMP)
-          Scmp.Type typeEnum = Scmp.Type.parse(type);
-          return extractPortFromPayload(data, hdrOffset + typeEnum.getHeaderLength());
-        }
-        throw new UnsupportedOperationException(hdrType.name() + " " + tc.getText());
+      switch (Scmp.Type.parse(type)) {
+        case INFO_128:
+        case INFO_130:
+          // request -> port is 30041
+          return Constants.SCMP_PORT;
+        case INFO_129:
+        case INFO_131:
+          // response -> get port from SCMP identifier
+          data.position(hdrOffset + 4);
+          return Short.toUnsignedInt(data.getShort());
+        default:
+          int code = ByteUtil.toUnsigned(data.get());
+          Scmp.TypeCode tc = Scmp.TypeCode.parse(type, code);
+          if (tc.isError()) {
+            // try extracting port from attached packet (may be UDP or SCMP)
+            Scmp.Type typeEnum = Scmp.Type.parse(type);
+            return extractPortFromPayload(data, hdrOffset + typeEnum.getHeaderLength());
+          }
+          return 0;
       }
     } else {
-      throw new UnsupportedOperationException();
+      // Unknown protocol.
+      return 0;
     }
-    return dstPort;
   }
 
   private static int extractSrcPort(
       ByteBuffer data, int hdrOffset, HeaderConstants.HdrTypes hdrType) {
-    int srcPort;
     if (hdrType == HeaderConstants.HdrTypes.UDP) {
       // get remote port from UDP overlay
       data.position(hdrOffset);
-      srcPort = Short.toUnsignedInt(data.getShort());
+      return Short.toUnsignedInt(data.getShort());
     } else if (hdrType == HeaderConstants.HdrTypes.SCMP) {
       // get remote port from SCMP header
       data.position(hdrOffset);
       int type = ByteUtil.toUnsigned(data.get());
-      Scmp.Type t = Scmp.Type.parse(type);
-      if (t == Scmp.Type.INFO_128 || t == Scmp.Type.INFO_130) {
-        // request -> get port from SCMP identifier
-        data.position(hdrOffset + 4);
-        srcPort = Short.toUnsignedInt(data.getShort());
-      } else {
-        // response or error -> port is 30041
-        srcPort = Constants.SCMP_PORT;
+      switch (Scmp.Type.parse(type)) {
+        case INFO_128:
+        case INFO_130:
+          // request -> get port from SCMP identifier
+          data.position(hdrOffset + 4);
+          return Short.toUnsignedInt(data.getShort());
+        case INFO_129:
+        case INFO_131:
+          // response or error -> port is 30041
+          return Constants.SCMP_PORT;
+        default:
+          // All errors and 200, 201, 255
+          return 0;
       }
     } else {
-      throw new UnsupportedOperationException();
+      return 0;
     }
-    return srcPort;
   }
 
   private static int extractPortFromPayload(ByteBuffer fullData, int hdrOffset) {
@@ -411,7 +387,7 @@ public class ScionHeaderParser {
     //  ? bit: DstHostAddr
     //  ? bit: SrcHostAddr
 
-    long dstIsdAs = data.getLong(); // TODO compare to local IsdAs?
+    long dstIsdAs = data.getLong(); // TODO match against local ISD/ASes
     long srcIsdAs = data.getLong();
 
     byte[] bytesDst = new byte[(dl + 1) * 4];

--- a/src/test/java/org/scion/jpan/api/ScmpResponderTest.java
+++ b/src/test/java/org/scion/jpan/api/ScmpResponderTest.java
@@ -69,12 +69,27 @@ class ScmpResponderTest {
 
   @Test
   void testEcho() throws IOException {
+    testEcho(null);
+  }
+
+  @Test
+  void testEcho_lowPort() throws IOException {
+    testEcho(12345);
+  }
+
+  @Test
+  void testEcho_highPort() throws IOException {
+    // Test that a "high" port is handled correctly, i.e. that it is correctly encoded in 16bits
+    testEcho(55555);
+  }
+
+  private void testEcho(Integer port) throws IOException {
     MockNetwork.startTiny();
     MockScmpHandler.stop(); // Shut down SCMP handler
     Path path = getPathTo112(InetAddress.getLoopbackAddress());
     // sender is in 110; responder is in 112
     ManagedThread responder = ManagedThread.newBuilder().build();
-    try (ScmpSender sender = Scmp.newSenderBuilder().build()) {
+    try (ScmpSender sender = Scmp.newSenderBuilder().setLocalPort(port).build()) {
       sender.setScmpErrorListener(scmpMessage -> errors.add(scmpMessage.getTypeCode().getText()));
       sender.setOption(ScionSocketOptions.SCION_API_THROW_PARSER_FAILURE, true);
 
@@ -91,6 +106,32 @@ class ScmpResponderTest {
     } finally {
       responder.stopNow();
       MockNetwork.stopTiny();
+    }
+  }
+
+  @Test
+  void testEchoWithSHIM() throws IOException {
+    // The SHIM includes a responder so we don't need to start an extra one.
+
+    MockNetwork.startTiny();
+    MockScmpHandler.stop(); // Shut down SCMP handler
+    Path path = getPathTo112(InetAddress.getLoopbackAddress());
+    // sender is in 110; responder/SHIM is in 112
+    Shim.install();
+    try (ScmpSender sender = Scmp.newSenderBuilder().build()) {
+      sender.setScmpErrorListener(scmpMessage -> errors.add(scmpMessage.getTypeCode().getText()));
+      sender.setOption(ScionSocketOptions.SCION_API_THROW_PARSER_FAILURE, true);
+
+      // send request
+      for (int i = 0; i < 10; i++) {
+        Scmp.EchoMessage msg = sender.sendEchoRequest(path, ByteBuffer.allocate(0));
+        assertNotNull(msg);
+        assertFalse(msg.isTimedOut(), "i=" + i);
+        assertEquals(Scmp.TypeCode.TYPE_129, msg.getTypeCode());
+      }
+    } finally {
+      MockNetwork.stopTiny();
+      Shim.uninstall();
     }
   }
 

--- a/src/test/java/org/scion/jpan/internal/ScionHeaderParserTest.java
+++ b/src/test/java/org/scion/jpan/internal/ScionHeaderParserTest.java
@@ -140,7 +140,7 @@ class ScionHeaderParserTest {
     ByteBuffer data = createScmpResponse(12345, Scmp.TypeCode.TYPE_5, PAYLOAD_SCMP_ERROR, false);
     InetSocketAddress addr = ScionHeaderParser.extractDestinationSocketAddress(data);
     assertNotNull(addr);
-    assertEquals(30041, addr.getPort());
+    assertEquals(0, addr.getPort());
   }
 
   @Test

--- a/src/test/java/org/scion/jpan/testutil/ManagedThread.java
+++ b/src/test/java/org/scion/jpan/testutil/ManagedThread.java
@@ -43,7 +43,11 @@ public class ManagedThread implements ManagedThreadNews {
   }
 
   private ManagedThread(
-      int nThreads, int startUpWaitMillis, String name, Class<? extends Exception> expectThrows, int timeoutMs) {
+      int nThreads,
+      int startUpWaitMillis,
+      String name,
+      Class<? extends Exception> expectThrows,
+      int timeoutMs) {
     this.name = name;
     this.startUpWaitMillis = startUpWaitMillis;
     this.expectThrows = expectThrows;

--- a/src/test/java/org/scion/jpan/testutil/ManagedThread.java
+++ b/src/test/java/org/scion/jpan/testutil/ManagedThread.java
@@ -32,6 +32,7 @@ public class ManagedThread implements ManagedThreadNews {
   private final String name;
   private final int startUpWaitMillis;
   private final Class<? extends Exception> expectThrows;
+  private final int timeoutMs;
 
   public interface MTRunnable {
     void run(ManagedThreadNews news) throws Exception;
@@ -42,10 +43,11 @@ public class ManagedThread implements ManagedThreadNews {
   }
 
   private ManagedThread(
-      int nThreads, int startUpWaitMillis, String name, Class<? extends Exception> expectThrows) {
+      int nThreads, int startUpWaitMillis, String name, Class<? extends Exception> expectThrows, int timeoutMs) {
     this.name = name;
     this.startUpWaitMillis = startUpWaitMillis;
     this.expectThrows = expectThrows;
+    this.timeoutMs = timeoutMs;
     if (nThreads == 1) {
       executor = Executors.newSingleThreadExecutor();
     } else {
@@ -65,7 +67,7 @@ public class ManagedThread implements ManagedThreadNews {
         });
 
     try {
-      if (!barrier.await(1, TimeUnit.SECONDS)) {
+      if (!barrier.await(timeoutMs, TimeUnit.MILLISECONDS)) {
         executor.shutdownNow();
         throw new IllegalStateException("Could not start managed thread: " + name);
       }
@@ -79,7 +81,7 @@ public class ManagedThread implements ManagedThreadNews {
   public void stopNow() {
     executor.shutdownNow();
     try {
-      if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
+      if (!executor.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
         checkExceptions();
         throw new IllegalStateException("Managed thread won't stop: " + name);
       }
@@ -91,7 +93,7 @@ public class ManagedThread implements ManagedThreadNews {
   }
 
   public void join() {
-    join(1000);
+    join(timeoutMs);
   }
 
   public void join(int millis) {
@@ -146,13 +148,19 @@ public class ManagedThread implements ManagedThreadNews {
     private final String name = "ManagedThread-" + System.identityHashCode(this);
     private final int nThreads = 1;
     private Class<? extends Exception> expectThrows = null;
+    private int timeoutMs = 1000;
 
     public ManagedThread build() {
-      return new ManagedThread(nThreads, startUpWaitMillis, name, expectThrows);
+      return new ManagedThread(nThreads, startUpWaitMillis, name, expectThrows, timeoutMs);
     }
 
     public Builder expectThrows(Class<? extends Exception> exClass) {
       this.expectThrows = exClass;
+      return this;
+    }
+
+    public Builder timeout(int timeoutMs) {
+      this.timeoutMs = timeoutMs;
       return this;
     }
   }


### PR DESCRIPTION
The SCMP parser incorrectly extracts src/dst port information, see #233.
This has no effect in the current implementation of SHIM or ScmpResponder.