### PR TITLE
Remove segment fetch minimizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   for SCMP packets that caused an error. 
 - Investigate why 5-10% of paths time out in MultiPing
 - Allow empty search domain "" (Francois)
-- Remove segment-fetch-optimizer
-- Add SacionService.setDefault(this) for subclasses
 - Peering: consider: https://github.com/scionproto/scion/tree/peering_test
 - PathProvider
   - Avoid register(), instead have a get() path function. Works better with
@@ -163,7 +161,7 @@ TODO
 - Added comprehensive integration test for demos.
   [#231](https://github.com/scionproto-contrib/jpan/pull/231)
 - ScionService.setDefaultService() for subclasses
-  [#237](https://github.com/scionproto-contrib/jpan/pull/237)
+  [#238](https://github.com/scionproto-contrib/jpan/pull/238)
 
 ### Fixed
 
@@ -222,6 +220,9 @@ TODO
   [#215](https://github.com/scionproto-contrib/jpan/pull/215)
 - SCMP and PathProvider clean up.
   [#216](https://github.com/scionproto-contrib/jpan/pull/216)
+- Removed segment fetch optimizer. It is pointless with the new endhost API.
+  BREAKING CHANGE: PROPERTY/ENV/DEFAULT_RESOLVER_MINIMIZE_REQUESTS have been removed
+  [#239](https://github.com/scionproto-contrib/jpan/pull/239)
 
 
 ## [0.6.1] - 2025-12-15

--- a/README.md
+++ b/README.md
@@ -400,21 +400,13 @@ Whether a SHIM is started can be controlled with a configuration option, see bel
 
 ### Other Options
 
-| Option                                                                                                               | Java property                                     | Environment variable                            | Default value      |
-|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|-------------------------------------------------|--------------------|
-| Timeout for daemon / control service (milliseconds).                                                                 | `org.scion.controlPlane.timeoutMs`                | `SCION_CONTROL_PLANE_TIMEOUT_MS`                |                    |
-| Location of `hosts` file. Multiple location can be specified separated by `;`.                                       | `org.scion.hostsFiles`                            | `SCION_HOSTS_FILES`                             | `/etc/scion/hosts` |
-| Path expiry margin. Before sending a packet a new path is requested if the path is about to expire within X seconds. | `org.scion.pathExpiryMargin`                      | `SCION_PATH_EXPIRY_MARGIN`                      | `10`               |
-| Path polling interval. Interval at which a client may poll for new paths for connected channels or sockets.          | `org.scion.pathPollIntervalSec`                   | `SCION_PATH_POLL_INTERVAL_SEC`                  | `60`               |
-| Minimize segment requests to local AS at the cost of reduced range of path available.                                | `org.scion.resolver.experimentalMinimizeRequests` | `EXPERIMENTAL_SCION_RESOLVER_MINIMIZE_REQUESTS` | `false`            |
-| Start SHIM. If not set, SHIM will be started unless the dispatcher port range is set to `all`.                       | `org.scion.shim`                                  | `SCION_SHIM`                                    |                    |
-
-`EXPERIMENTAL_SCION_RESOLVER_MINIMIZE_REQUESTS` is a non-standard option that requests CORE segments only 
-if noother path can be constructed. This may reduce response time when requesting new paths. It is very likely,
-but not guaranteed, that the shortest path (fewest hops) will be available. 
-If this property is not set (= default), CORE segments are always requested, resulting in additional
-path options. While these additional path options almost always result in longer paths, they may have 
-other advantages.  
+| Option                                                                                                               | Java property                       | Environment variable              | Default value      |
+|----------------------------------------------------------------------------------------------------------------------|-------------------------------------|-----------------------------------|--------------------|
+| Timeout for daemon / control service (milliseconds).                                                                 | `org.scion.controlPlane.timeoutMs`  | `SCION_CONTROL_PLANE_TIMEOUT_MS`  |                    |
+| Location of `hosts` file. Multiple location can be specified separated by `;`.                                       | `org.scion.hostsFiles`              | `SCION_HOSTS_FILES`               | `/etc/scion/hosts` |
+| Path expiry margin. Before sending a packet a new path is requested if the path is about to expire within X seconds. | `org.scion.pathExpiryMargin`        | `SCION_PATH_EXPIRY_MARGIN`        | `10`               |
+| Path polling interval. Interval at which a client may poll for new paths for connected channels or sockets.          | `org.scion.pathPollIntervalSec`     | `SCION_PATH_POLL_INTERVAL_SEC`    | `60`               |
+| Start SHIM. If not set, SHIM will be started unless the dispatcher port range is set to `all`.                       | `org.scion.shim`                    | `SCION_SHIM`                      |                    |
 
 ## FAQ / Troubleshooting
 

--- a/src/main/java/org/scion/jpan/Constants.java
+++ b/src/main/java/org/scion/jpan/Constants.java
@@ -98,16 +98,6 @@ public final class Constants {
    */
   public static final String ENV_HOSTS_FILES = "SCION_HOSTS_FILES";
 
-  /** Enable minimization of segment requests during path construction. */
-  public static final String PROPERTY_RESOLVER_MINIMIZE_REQUESTS =
-      "EXPERIMENTAL_SCION_RESOLVER_MINIMIZE_REQUESTS";
-
-  /** Enable minimization of segment requests during path construction. */
-  public static final String ENV_RESOLVER_MINIMIZE_REQUESTS =
-      "org.scion.resolver.experimentalMinimizeRequests";
-
-  public static final boolean DEFAULT_RESOLVER_MINIMIZE_REQUESTS = false;
-
   /**
    * Disable usage of OS search domains for DNS lookup, e.g. from /etc/resolv.conf. This needs to be
    * disabled for JUnit testing.

--- a/src/main/java/org/scion/jpan/ScionService.java
+++ b/src/main/java/org/scion/jpan/ScionService.java
@@ -61,7 +61,6 @@ public class ScionService {
   private final PathServiceRpc pathService;
   private final DaemonServiceGrpc daemonService;
 
-  private final boolean minimizeRequests;
   private Thread shutdownHook;
 
   protected enum Mode {
@@ -73,11 +72,6 @@ public class ScionService {
   }
 
   protected ScionService(String addressOrHost, Mode mode) {
-    minimizeRequests =
-        ScionUtil.getPropertyOrEnv(
-            Constants.PROPERTY_RESOLVER_MINIMIZE_REQUESTS,
-            Constants.ENV_RESOLVER_MINIMIZE_REQUESTS,
-            Constants.DEFAULT_RESOLVER_MINIMIZE_REQUESTS);
     if (mode == Mode.DAEMON) {
       LOG.info("Bootstrapping with daemon service: {}", addressOrHost);
       addressOrHost = IPHelper.ensurePortOrDefault(addressOrHost, DEFAULT_DAEMON_PORT);
@@ -367,7 +361,7 @@ public class ScionService {
     } else {
       // query control service
       long srcIsdAs = getLocalIsdAs();
-      list = Segments.getPathsCS(controlService, localAS, srcIsdAs, dstIsdAs, minimizeRequests);
+      list = Segments.getPathsCS(controlService, localAS, srcIsdAs, dstIsdAs);
     }
     if (LOG.isInfoEnabled()) {
       LOG.info("Paths found to {}: {}", ScionUtil.toStringIA(dstIsdAs), list.size());

--- a/src/main/java/org/scion/jpan/internal/paths/Segments.java
+++ b/src/main/java/org/scion/jpan/internal/paths/Segments.java
@@ -70,31 +70,17 @@ public class Segments {
    * @param localAS local AS info
    * @param srcIsdAs source ISD/AS
    * @param dstIsdAs destination ISD/AS
-   * @param minimizeLookups If 'true', this attempts to reduce the number of segment request when
-   *     constructing a paths. This comes at the cost of having less path variety to chose from,
-   *     however, the shortest paths should always be available (unless there is a path with a CORE
-   *     segment that is shorter than a pure UP and/or DOWN path). This is similar, but not equal
-   *     to, depth-first search as proposed in the Scion book 2022, page 82.
    * @return list of available paths (unordered)
    */
   public static List<PathMetadata> getPathsCS(
-      ControlServiceGrpc service,
-      LocalAS localAS,
-      long srcIsdAs,
-      long dstIsdAs,
-      boolean minimizeLookups) {
-    List<PathMetadata> path =
-        getPathsInternal(service, localAS, srcIsdAs, dstIsdAs, minimizeLookups);
+      ControlServiceGrpc service, LocalAS localAS, long srcIsdAs, long dstIsdAs) {
+    List<PathMetadata> path = getPathsInternal(service, localAS, srcIsdAs, dstIsdAs);
     path.sort(Comparator.comparingInt(pm -> pm.getInterfaces().size()));
     return path;
   }
 
   private static List<PathMetadata> getPathsInternal(
-      ControlServiceGrpc service,
-      LocalAS localAS,
-      long srcIsdAs,
-      long dstIsdAs,
-      boolean minimizeLookups) {
+      ControlServiceGrpc service, LocalAS localAS, long srcIsdAs, long dstIsdAs) {
     long srcWildcard = ScionUtil.toWildcard(srcIsdAs);
     long dstWildcard = ScionUtil.toWildcard(dstIsdAs);
 
@@ -115,15 +101,6 @@ public class Segments {
       segmentsUp = getSegments(service, srcIsdAs, srcWildcard);
       if (segmentsUp.isEmpty()) {
         return Collections.emptyList();
-      }
-      if (minimizeLookups) {
-        List<PathSegment> directUp = filterForIsdAs(segmentsUp, dstIsdAs);
-        if (!directUp.isEmpty()) {
-          // DST is core or on-path
-          PathDuplicationFilter paths = new PathDuplicationFilter();
-          combineSegment(paths, directUp, localAS, srcIsdAs, dstIsdAs);
-          return paths.getPaths();
-        }
       }
     }
 
@@ -185,7 +162,7 @@ public class Segments {
 
   /**
    * Lookup segments, construct paths, and return paths from a path service (new endhost API). See
-   * {@link #getPathsCS(ControlServiceGrpc, LocalAS, long, long, boolean)}.
+   * {@link #getPathsCS(ControlServiceGrpc, LocalAS, long, long)}.
    *
    * @param service PathService
    * @param localAS This provides the local interface address

--- a/src/test/java/org/scion/jpan/PackageVisibilityHelper.java
+++ b/src/test/java/org/scion/jpan/PackageVisibilityHelper.java
@@ -45,13 +45,8 @@ public class PackageVisibilityHelper {
   }
 
   public static List<PathMetadata> getPathsCS(ScionService ss, long srcIsdAs, long dstIsdAs) {
-    boolean minimizeRequests =
-        ScionUtil.getPropertyOrEnv(
-            Constants.PROPERTY_RESOLVER_MINIMIZE_REQUESTS,
-            Constants.ENV_RESOLVER_MINIMIZE_REQUESTS,
-            Constants.DEFAULT_RESOLVER_MINIMIZE_REQUESTS);
     ControlServiceGrpc cs = ss.getControlServiceConnection();
-    return Segments.getPathsCS(cs, ss.getLocalAS(), srcIsdAs, dstIsdAs, minimizeRequests);
+    return Segments.getPathsCS(cs, ss.getLocalAS(), srcIsdAs, dstIsdAs);
   }
 
   public static HeaderConstants.HdrTypes getNextHdr(ByteBuffer packet) {

--- a/src/test/java/org/scion/jpan/ProtobufPathDemo.java
+++ b/src/test/java/org/scion/jpan/ProtobufPathDemo.java
@@ -149,7 +149,7 @@ public class ProtobufPathDemo {
     ScionService csService =
         Scion.newServiceWithTopologyFile("topologies/tiny4/ASff00_0_112/topology.json");
     ControlServiceGrpc cs = PackageVisibilityHelper.getControlService(csService);
-    List<PathMetadata> paths = Segments.getPathsCS(cs, csService.getLocalAS(), srcIA, dstIA, false);
+    List<PathMetadata> paths = Segments.getPathsCS(cs, csService.getLocalAS(), srcIA, dstIA);
     System.out.println("Paths found: " + paths.size());
     for (PathMetadata path : paths) {
       System.out.println("Path:  exp=" + path.getExpiration() + "  mtu=" + path.getMtu());

--- a/src/test/java/org/scion/jpan/internal/SegmentsDefault112Test.java
+++ b/src/test/java/org/scion/jpan/internal/SegmentsDefault112Test.java
@@ -47,7 +47,6 @@ class SegmentsDefault112Test extends AbstractSegmentsTest {
     DNSUtil.clear();
     // Defensive clean up
     ScionService.closeDefault();
-    System.clearProperty(Constants.PROPERTY_RESOLVER_MINIMIZE_REQUESTS);
   }
 
   @Test

--- a/src/test/java/org/scion/jpan/internal/SegmentsDefault131Test.java
+++ b/src/test/java/org/scion/jpan/internal/SegmentsDefault131Test.java
@@ -47,7 +47,6 @@ class SegmentsDefault131Test extends AbstractSegmentsTest {
     DNSUtil.clear();
     // Defensive clean up
     ScionService.closeDefault();
-    System.clearProperty(Constants.PROPERTY_RESOLVER_MINIMIZE_REQUESTS);
   }
 
   @Test

--- a/src/test/java/org/scion/jpan/internal/SegmentsMinimal1111Test.java
+++ b/src/test/java/org/scion/jpan/internal/SegmentsMinimal1111Test.java
@@ -62,7 +62,6 @@ class SegmentsMinimal1111Test extends AbstractSegmentsTest {
     DNSUtil.clear();
     // Defensive clean up
     ScionService.closeDefault();
-    System.clearProperty(Constants.PROPERTY_RESOLVER_MINIMIZE_REQUESTS);
   }
 
   @Test
@@ -130,7 +129,7 @@ class SegmentsMinimal1111Test extends AbstractSegmentsTest {
     }
 
     assertEquals(1, network.getTopoServer().getAndResetCallCount());
-    assertEquals(1, network.getControlServer().getAndResetCallCount());
+    assertEquals(2, network.getControlServer().getAndResetCallCount());
   }
 
   @Test
@@ -186,17 +185,6 @@ class SegmentsMinimal1111Test extends AbstractSegmentsTest {
 
   @Test
   void caseE_SameIsd_UpDown_OneCoreAS_OnPathUp() {
-    caseE_SameIsd_UpDown_OneCoreAS_OnPathUp(false);
-  }
-
-  @Test
-  void caseE_SameIsd_UpDown_OneCoreAS_OnPathUp_MinRequests() {
-    caseE_SameIsd_UpDown_OneCoreAS_OnPathUp(true);
-  }
-
-  private void caseE_SameIsd_UpDown_OneCoreAS_OnPathUp(boolean minRequests) {
-    System.setProperty(
-        Constants.PROPERTY_RESOLVER_MINIMIZE_REQUESTS, Boolean.toString(minRequests));
     try (Scion.CloseableService ss = Scion.newServiceWithDNS(AS_HOST)) {
       List<PathMetadata> paths = PackageVisibilityHelper.getPathsCS(ss, AS_1111, AS_111);
       //  Available paths to 1-ff00:0:1112
@@ -238,7 +226,7 @@ class SegmentsMinimal1111Test extends AbstractSegmentsTest {
       assertEquals(2, path.getInterfaces().size());
     }
     assertEquals(1, network.getTopoServer().getAndResetCallCount());
-    assertEquals(minRequests ? 1 : 3, network.getControlServer().getAndResetCallCount());
+    assertEquals(3, network.getControlServer().getAndResetCallCount());
   }
 
   @Test

--- a/src/test/java/org/scion/jpan/internal/SegmentsMinimal111Test.java
+++ b/src/test/java/org/scion/jpan/internal/SegmentsMinimal111Test.java
@@ -62,7 +62,6 @@ class SegmentsMinimal111Test extends AbstractSegmentsTest {
     DNSUtil.clear();
     // Defensive clean up
     ScionService.closeDefault();
-    System.clearProperty(Constants.PROPERTY_RESOLVER_MINIMIZE_REQUESTS);
   }
 
   @Test
@@ -85,16 +84,6 @@ class SegmentsMinimal111Test extends AbstractSegmentsTest {
 
   @Test
   void caseB_SameIsd_Up() {
-    caseB_SameIsd_Up(false);
-  }
-
-  @Test
-  void caseB_SameIsd_Up_MinimizeRequests() {
-    caseB_SameIsd_Up(true);
-  }
-
-  private void caseB_SameIsd_Up(boolean minimize) {
-    System.setProperty(Constants.PROPERTY_RESOLVER_MINIMIZE_REQUESTS, Boolean.toString(minimize));
     try (Scion.CloseableService ss = Scion.newServiceWithDNS(AS_HOST)) {
       List<PathMetadata> paths = PackageVisibilityHelper.getPathsCS(ss, AS_111, AS_110);
       //    scion showpaths 1-ff00:0:110 --sciond 127.0.0.27:30255
@@ -134,7 +123,7 @@ class SegmentsMinimal111Test extends AbstractSegmentsTest {
     }
 
     assertEquals(1, network.getTopoServer().getAndResetCallCount());
-    assertEquals(minimize ? 1 : 2, network.getControlServer().getAndResetCallCount());
+    assertEquals(2, network.getControlServer().getAndResetCallCount());
   }
 
   @Test


### PR DESCRIPTION
Remove segment fetch minimizer. It was always experimental and will be useless with the new endhost API.