### PR TITLE
Endhost API service names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,8 @@ TODO
   [#231](https://github.com/scionproto-contrib/jpan/pull/231)
 - ScionService.setDefaultService() for subclasses
   [#238](https://github.com/scionproto-contrib/jpan/pull/238)
+- Configurable service point name for new endhost API
+  [#241](https://github.com/scionproto-contrib/jpan/pull/241) 
 
 ### Fixed
 

--- a/src/main/java/org/scion/jpan/Constants.java
+++ b/src/main/java/org/scion/jpan/Constants.java
@@ -167,6 +167,14 @@ public final class Constants {
   public static final String ENV_NAT_STUN_TIMEOUT_MS = "SCION_NAT_STUN_TIMEOUT_MS";
   public static final int DEFAULT_NAT_STUN_TIMEOUT_MS = 10;
 
+  /** New ENdhost API: Configurable API names */
+  public static final String PROPERTY_NAPI_SEGMENT_SERVICE_NAME =
+      "org.scion.napi.segment.service.name";
+
+  public static final String ENV_NAPI_SEGMENT_SERVICE_NAME = "SCION_NAPI_SEGMENT_SERVICE_NAME";
+  public static final String DEFAULT_NAPI_SEGMENT_SERVICE_NAME =
+      "scion.endhost.v1.PathService/ListPaths";
+
   /**
    * Non-public property that allows ignoring all environment variables. This is useful for running
    * the tests on a host with a SCION installation.

--- a/src/main/java/org/scion/jpan/internal/paths/PathServiceRpc.java
+++ b/src/main/java/org/scion/jpan/internal/paths/PathServiceRpc.java
@@ -25,6 +25,7 @@ import okhttp3.ResponseBody;
 import org.scion.jpan.ScionRuntimeException;
 import org.scion.jpan.ScionUtil;
 import org.scion.jpan.internal.bootstrap.LocalAS;
+import org.scion.jpan.internal.util.Config;
 import org.scion.jpan.proto.endhost.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +61,8 @@ public class PathServiceRpc {
       ps.init();
       Request request =
           new Request.Builder()
-              .url("http://" + ps.address + "/scion.endhost.v1.PathService/ListPaths")
+              // .url("http://" + ps.address + "/scion.endhost.v1.PathService/ListPaths")
+              .url("http://" + ps.address + "/" + Config.getNApiSegmentServiceName())
               .addHeader("Content-type", "application/proto")
               //            .addHeader("User-Agent", "OkHttp Bot")
               .post(requestBody)

--- a/src/main/java/org/scion/jpan/internal/util/Config.java
+++ b/src/main/java/org/scion/jpan/internal/util/Config.java
@@ -74,4 +74,11 @@ public class Config {
         ENV_PATH_POLLING_INTERVAL_SEC,
         DEFAULT_PATH_POLLING_INTERVAL);
   }
+
+  public static String getNApiSegmentServiceName() {
+    return ScionUtil.getPropertyOrEnv(
+        PROPERTY_NAPI_SEGMENT_SERVICE_NAME,
+        ENV_NAPI_SEGMENT_SERVICE_NAME,
+        DEFAULT_NAPI_SEGMENT_SERVICE_NAME);
+  }
 }

--- a/src/main/proto/scion/protobuf/endhost/v1/service.proto
+++ b/src/main/proto/scion/protobuf/endhost/v1/service.proto
@@ -9,5 +9,5 @@ import "scion/protobuf/endhost/v1/path.proto";
 
 service PathService {
   // Segments returns all segments that match the request.
-  rpc ListPaths(.endhost.api_service.v1.ListSegmentsRequest) returns (.endhost.api_service.v1.ListSegmentsResponse) {}
+  rpc ListSegments(.endhost.api_service.v1.ListSegmentsRequest) returns (.endhost.api_service.v1.ListSegmentsResponse) {}
 }

--- a/src/test/java/org/scion/jpan/testutil/MockPathService.java
+++ b/src/test/java/org/scion/jpan/testutil/MockPathService.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.scion.jpan.ScionUtil;
+import org.scion.jpan.internal.util.Config;
 import org.scion.jpan.proto.control_plane.Seg;
 import org.scion.jpan.proto.endhost.Path;
 import org.scion.jpan.proto.endhost.Underlays;
@@ -63,7 +64,7 @@ public class MockPathService {
     try {
       pathService = new MockPathService.PathServiceImpl(port);
     } catch (IOException e) {
-      throw new RuntimeException("port=" + port, e);
+      throw new RuntimeException("port=" + port + ";api=" + Config.getNApiSegmentServiceName(), e);
     }
 
     // Wait for server to start


### PR DESCRIPTION
Make the name of the PathService API configurable. This is a temporary feature and mostly for the upcoming renaming in the endhost API.