### PR TITLE
NAT reset on disconnect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,8 @@ TODO
 
 - Refactored ScionService
   [#257](https://github.com/scionproto-contrib/jpan/issues/257)
+- `disconnect()` doe not anymore reset the NAT mapping.
+  [#246](https://github.com/scionproto-contrib/jpan/issues/246)
 
 
 ## [0.7.0] - 2026-04-29

--- a/src/main/java/org/scion/jpan/AbstractScionChannel.java
+++ b/src/main/java/org/scion/jpan/AbstractScionChannel.java
@@ -229,7 +229,6 @@ abstract class AbstractScionChannel<C extends AbstractScionChannel<?>> implement
   public void disconnect() throws IOException {
     synchronized (stateLock) {
       connectionPath = null;
-      natMapping = null;
       pathProvider.disconnect();
     }
   }

--- a/src/test/java/org/scion/jpan/internal/NatMappingTest.java
+++ b/src/test/java/org/scion/jpan/internal/NatMappingTest.java
@@ -568,6 +568,7 @@ class NatMappingTest {
 
   void testDisconnectWithSend(boolean testReceive) throws IOException {
     // Disconnect should reset the NAT mapping.
+    // #246: Why? -> Changed to _not_ reset the NAT mapping on disconnect. Only close() should.
     // Being on localhost and having no actual NAT, we can only count the number of STUN messages.
     System.setProperty(Constants.PROPERTY_NAT, "BR");
     MockNetwork.startTiny();
@@ -590,8 +591,10 @@ class NatMappingTest {
         sendBuffer.flip();
         channelSend.send(sendBuffer, path);
       }
-      // Now there should have been two more STUN packets
-      assertEquals(2, MockNetwork.getAndResetStunCount());
+      // Now there should have been no (previously: two) more STUN packets
+      // Changed behavior, see #246. Why should be reset the NAT on disconnect?
+      // -> We keep the NAT.
+      assertEquals(0, MockNetwork.getAndResetStunCount());
 
       // finish
       receiver.join(10);


### PR DESCRIPTION
Fix for #246.
The original problem is a race condition. However, instead of synchronizing access, we removed NAT `reset()` from the `disconnect()`.
(It was badly implemented anyway, missing a `NatMapping.close()`).
Instead, we keep the `NatMapping` open until `close()`.